### PR TITLE
Allow higher number of threads than 8

### DIFF
--- a/epregressions/main_window.py
+++ b/epregressions/main_window.py
@@ -612,7 +612,7 @@ class RegressionGUI(Gtk.Window):
             n_threads_max = cpu_count()
             if n_threads_max is None:
                 # If couldn't be determined, assume 8 as default
-                n_threads_max = 8
+                n_threads_max = 8  # pragma: no cover -- I cant imagine a way to get cpu_count to fail
             self.suite_option_num_threads.set_range(1, n_threads_max)
             self.suite_option_num_threads.set_increments(1, 4)
             self.suite_option_num_threads.spin(Gtk.SpinType.PAGE_FORWARD, 1)

--- a/epregressions/main_window.py
+++ b/epregressions/main_window.py
@@ -30,7 +30,8 @@ from epregressions.builds.install import EPlusInstallDirectory
 if sys.version_info.major > 2:
     from os import cpu_count
 else:
-    from multiprocessing import cpu_count
+    from multiprocessing import cpu_count  # pragma: no cover
+    # I'm not sure why this isn't covered by the Py2 test, but it doesn't seem to be
 
 # graphics stuff
 import gi

--- a/epregressions/main_window.py
+++ b/epregressions/main_window.py
@@ -602,7 +602,12 @@ class RegressionGUI(Gtk.Window):
         if platform() != Platforms.Windows:
             num_threads_box = Gtk.HBox(homogeneous=False, spacing=box_spacing)
             self.suite_option_num_threads = Gtk.SpinButton()
-            self.suite_option_num_threads.set_range(1, 8)
+            # Determine max available threads
+            n_threads_max = os.cpu_count()
+            if n_threads_max is None:
+                # If couldn't be determined, assume 8 as default
+                n_threads_max = 8
+            self.suite_option_num_threads.set_range(1, n_threads_max)
             self.suite_option_num_threads.set_increments(1, 4)
             self.suite_option_num_threads.spin(Gtk.SpinType.PAGE_FORWARD, 1)
             self.suite_option_num_threads.connect("value-changed", self.suite_option_handler_num_threads)

--- a/epregressions/main_window.py
+++ b/epregressions/main_window.py
@@ -4,6 +4,7 @@ from datetime import datetime  # datetime allows us to generate timestamps for t
 import glob
 import json
 import os
+import sys
 import random
 import subprocess  # subprocess allows us to spawn the help pdf separately
 import threading  # threading allows for the test suite to run multiple E+ runs concurrently
@@ -25,6 +26,11 @@ from epregressions.builds.base import KnownBuildTypes
 from epregressions.builds.makefile import CMakeCacheMakeFileBuildDirectory
 from epregressions.builds.visualstudio import CMakeCacheVisualStudioBuildDirectory
 from epregressions.builds.install import EPlusInstallDirectory
+
+if sys.version_info.major > 2:
+    from os import cpu_count
+else:
+    from multiprocessing import cpu_count
 
 # graphics stuff
 import gi
@@ -603,7 +609,7 @@ class RegressionGUI(Gtk.Window):
             num_threads_box = Gtk.HBox(homogeneous=False, spacing=box_spacing)
             self.suite_option_num_threads = Gtk.SpinButton()
             # Determine max available threads
-            n_threads_max = os.cpu_count()
+            n_threads_max = cpu_count()
             if n_threads_max is None:
                 # If couldn't be determined, assume 8 as default
                 n_threads_max = 8

--- a/epregressions/runtests.py
+++ b/epregressions/runtests.py
@@ -208,22 +208,9 @@ class SuiteRunner:
 
                 # read in the entire text of the idf to do some special operations;
                 # could put in one line, but the with block ensures the file handle is closed
-
-                # Note: JM 2015-03-08: Absolutely need to make sure this
-                # doesn't fail, or it'll just hang with no activity and no
-                # warnings, so we'll try utf-8, fallback to latin-1, and if
-                # it fails, we try utf-8 and 'replace', if not it raises
-                try:
-                    _p = os.path.join(test_run_directory, self.ep_in_filename)
-                    idf_text = self.my_read_safe_encoding(_p)
-                except UnicodeDecodeError:
-                    # Worst case scenario, we just skip that file
-                    msg = "Reading {} failed, skipping".format(idf_path)
-                    # Print to console (dev warning)
-                    print(msg)
-                    # And to the GUI
-                    self.my_print(msg)
-                    continue
+                with io.open(os.path.join(test_run_directory, self.ep_in_filename), encoding='utf-8') as f_idf:
+                    idf_text = f_idf.read()  # EDWIN: Make sure this reads the IDF properly
+                    # idf_text = unicode(idf_text, errors='ignore')
 
                 # if the file requires the window 5 data set file, bring it into the test run directory
                 if 'Window5DataFile.dat' in idf_text:
@@ -764,63 +751,6 @@ class SuiteRunner:
 
     def interrupt_please(self):  # pragma: no cover
         self.id_like_to_stop_now = True
-
-    def my_read_safe_encoding(self, path):
-        """
-        Helper functiont that will read a file handling possible problems.
-        It will try the following order:
-            * Read as utf-8, errors='strict'
-            * Read as latin-1, errors='strict'
-            * Read as utf-8, errors='replace'
-            * If all failed, raise `UnicodeDecodeError`
-
-        Args:
-        -----
-        * path (str): path to the file to read
-
-        Returns:
-        --------
-        * idf_text (str): the decoded file content
-        """
-
-        msg = "Cannot read '{p}'".format(p=path)
-        msg += " with encoding={c}, errors={e}"
-        try:
-            encoding = 'utf-8'
-            errors = 'strict'
-            with io.open(path, 'r', encoding=encoding, errors=errors) as f_idf:
-                idf_text = f_idf.read()
-        except UnicodeDecodeError:
-            # Output to console (dev warning of sorts)
-            # AND the GUI
-            thismsg = ("{}, falling back to "
-                       "latin-1".format(msg.format(c=encoding, e=errors)))
-            print(thismsg)
-            self.my_print(thismsg)
-
-            encoding = 'latin-1'
-            errors = 'strict'
-
-            try:
-                with io.open(path, 'r',
-                             encoding=encoding, errors=errors) as f_idf:
-                    idf_text = f_idf.read()
-            except ValueError:
-                thismsg = ("{}, falling back to utf-8, errors='replace'"
-                           "".format(msg.format(c=encoding, e=errors)))
-                print(thismsg)
-                self.my_print(thismsg)
-                encoding = 'utf-8'
-                errors = 'replace'
-                try:
-                    with io.open(path, 'r', encoding=encoding,
-                                 errors=errors) as f_idf:
-                        idf_text = f_idf.read()
-                except UnicodeDecodeError:
-                    # This time it's bad, we raise
-                    raise UnicodeDecodeError(msg.format(c=encoding, e=errors))
-
-        return idf_text
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Fix #33: use `os.cpu_count()` to set the high range of number of threads in main_window.py

Fix #32: Handle files that could have non-UTF-8 encoding (at least: AirflowNetwork_MultiAirLoops, AirflowNetwork_PressureControl)

@Myoldmopar 