### PR TITLE
Strip Extraneous Whitespace from CSV Headers

### DIFF
--- a/epregressions/diffs/mycsv.py
+++ b/epregressions/diffs/mycsv.py
@@ -141,4 +141,8 @@ def getlist(fname):
             break
     if onecolumn:
         mat = transpose2d(mat)[0]
+
+    # trim extraneous whitespace from csv headers
+    mat[0] = [x.strip() for x in mat[0]]
+
     return mat

--- a/epregressions/diffs/mycsv.py
+++ b/epregressions/diffs/mycsv.py
@@ -141,8 +141,9 @@ def getlist(fname):
             break
     if onecolumn:
         mat = transpose2d(mat)[0]
-
-    # trim extraneous whitespace from csv headers
-    mat[0] = [x.strip() for x in mat[0]]
+        mat[0] = mat[0].strip()
+    else:
+        # trim extraneous whitespace from csv headers
+        mat[0] = [x.strip() for x in mat[0]]
 
     return mat

--- a/epregressions/tests/diffs/test_mycsv.py
+++ b/epregressions/tests/diffs/test_mycsv.py
@@ -153,3 +153,24 @@ class TestGetList(unittest.TestCase):
         self.assertEqual(3, len(response))
         for row in response:
             self.assertIsInstance(row, list)
+
+    def test_get_list_one_column_with_extra_whitespace(self):
+        csv_string = 'header_col_1 \n2_1\n2_2\n31\n32\n'
+        response = getlist(csv_string)
+        self.assertIsInstance(response, list)
+        self.assertEqual(5, len(response))
+        for row in response:
+            self.assertIsInstance(row, str)
+
+        self.assertEqual(response[0], 'header_col_1')
+
+    def test_get_list_two_columns_with_extra_whitespace(self):
+        csv_string = 'header_col_1 ,header_col_2 \n2_1,2_2\n31,32\n'
+        response = getlist(csv_string)
+        self.assertIsInstance(response, list)
+        self.assertEqual(3, len(response))
+        for row in response:
+            self.assertIsInstance(row, list)
+
+        self.assertEqual(response[0][0], 'header_col_1')
+        self.assertEqual(response[0][1], 'header_col_2')


### PR DESCRIPTION
As noted in the title, this just strips extraneous whitespace from the csv headers. Previously, mathdiff would fail to compare data where one header had extra whitespace, such as ```header_data_1,``` and ```header_data_1 ,```.