### PR TITLE
Add Notification on Linux and Mac

### DIFF
--- a/epregressions/tk_window.py
+++ b/epregressions/tk_window.py
@@ -901,6 +901,14 @@ class MyApp(Frame):
     def done_handler(self, results: CompletedStructure):
         self.add_to_log("All done, finished")
         self.label_string.set("Hey, all done!")
+        if system() == 'Linux':
+            subprocess.call(['notify-send', 'EnergyPlus Regression Tool', 'Regressions Finished'])
+        elif system() == 'Darwin':
+            subprocess.call([
+                'osascript',
+                '-e',
+                'display notification "Regressions Finished" with title "EnergyPlus Regression Tool"'
+            ])
         self.build_results_tree(results)
         self.client_done()
 


### PR DESCRIPTION
Pops open a notification bubble on Linux and Mac when the simulations are complete.  Windows doesn't have it yet...if someone can find me a one-liner to show a notification on Windows that doesn't involve a third-party Python package or some overly complex PowerShell then I'm happy to add that too.

FYI @jmythms