### PR TITLE
Ignore version change in diffs

### DIFF
--- a/epregressions/diffs/table_diff.py
+++ b/epregressions/diffs/table_diff.py
@@ -468,7 +468,10 @@ def table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file
                 # Statistics local to this table
                 for diff_result in diff_dict[h]:
                     diff_type = diff_result[2]
-                    if diff_type == 'small':
+                    if h == 'Version ID':
+                        table_equal += 1
+                        count_of_equal += 1
+                    elif diff_type == 'small':
                         table_small_diff += 1
                         count_of_small_diff += 1
                     elif diff_type == 'big':

--- a/epregressions/diffs/thresh_dict.py
+++ b/epregressions/diffs/thresh_dict.py
@@ -76,6 +76,9 @@ class ThreshDict(object):
         if hstr == 'Date/Time' or hstr == 'Time':
             return 0.0, 0.0
 
+        if hstr == 'Version ID':  # allow version number changes to pass without throwing table diffs
+            return 100.0, 100.0
+
         # Parse hstr (column header) to extract Unit and Aggregation
 
         # noinspection PyBroadException

--- a/epregressions/runtests.py
+++ b/epregressions/runtests.py
@@ -446,7 +446,7 @@ class SuiteRunner:
         txt1_cleaned = []
         skip_strings = [
             "Program Version,EnergyPlus",
-            "Version, ",
+            "Version,",
             "EnergyPlus Completed",
             "EnergyPlus Terminated",
             "DElight input generated",

--- a/epregressions/runtests.py
+++ b/epregressions/runtests.py
@@ -446,6 +446,7 @@ class SuiteRunner:
         txt1_cleaned = []
         skip_strings = [
             "Program Version,EnergyPlus",
+            "Version, ",
             "EnergyPlus Completed",
             "EnergyPlus Terminated",
             "DElight input generated",

--- a/epregressions/tests/diffs/tbl_resources/eplustbl_versiondiff_base.htm
+++ b/epregressions/tests/diffs/tbl_resources/eplustbl_versiondiff_base.htm
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=InitializationSummary::EntireFacility></a>
+<p>Report:<b> Initialization Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2021-10-05
+    16:53:24</b></p>
+<b>Version</b><br><br>
+<!-- FullName:Initialization Summary_Entire Facility_Version-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Version ID</td>
+  </tr>
+  <tr>
+    <td align="right">1</td>
+    <td align="right">9.6</td>
+  </tr>
+</table>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Net Conditioned Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Unconditioned Building Area</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+</body>
+</html>

--- a/epregressions/tests/diffs/tbl_resources/eplustbl_versiondiff_mod.htm
+++ b/epregressions/tests/diffs/tbl_resources/eplustbl_versiondiff_mod.htm
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=InitializationSummary::EntireFacility></a>
+<p>Report:<b> Initialization Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2021-10-05
+    16:53:24</b></p>
+<b>Version</b><br><br>
+<!-- FullName:Initialization Summary_Entire Facility_Version-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Version ID</td>
+  </tr>
+  <tr>
+    <td align="right">1</td>
+    <td align="right">22.1</td>
+  </tr>
+</table>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Net Conditioned Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Unconditioned Building Area</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+</body>
+</html>

--- a/epregressions/tests/diffs/test_table_diff.py
+++ b/epregressions/tests/diffs/test_table_diff.py
@@ -409,3 +409,24 @@ class TestMathDiff(unittest.TestCase):
         self.assertEqual(0, response[6])  # size errors
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
         self.assertEqual(0, response[8])  # in file 1 but not in file 2
+
+    def test_ignore_version_diff(self):
+        # This table has a version number difference
+        response = table_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplustbl_versiondiff_base.htm'),
+            os.path.join(self.diff_files_dir, 'eplustbl_versiondiff_mod.htm'),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(4, response[1])  # count_of_tables
+        self.assertEqual(0, response[2])  # big diffs  # TODO This is zero
+        self.assertEqual(0, response[3])  # small diffs
+        self.assertEqual(18, response[4])  # equals
+        self.assertEqual(0, response[5])  # string diffs
+        self.assertEqual(0, response[6])  # size errors
+        self.assertEqual(0, response[7])  # in file 2 but not in file 1
+        self.assertEqual(0, response[8])  # in file 1 but not in file 2

--- a/epregressions/tests/test_runtests.py
+++ b/epregressions/tests/test_runtests.py
@@ -2071,6 +2071,17 @@ class TestTestSuiteRunner(unittest.TestCase):
         self.assertEqual(EndErrSummary.STATUS_MISSING, results_for_file.summary_result.simulation_status_case1)
         self.assertEqual(EndErrSummary.STATUS_MISSING, results_for_file.summary_result.simulation_status_case2)
 
+    def test_eio_with_version(self):
+        # tests that the Version, XX.N line is ignored in the EIO
+        base_eio = os.path.join(self.temp_mod_source_dir, 'base.eio')
+        mod_eio = os.path.join(self.temp_mod_source_dir, 'mod.eio')
+        with open(base_eio, 'w') as f:
+            f.write(' ! <Version>, Version ID\nVersion, 9.6\n')
+        with open(mod_eio, 'w') as f:
+            f.write(' ! <Version>, Version ID\nVersion, 22.1\n')
+        diff_file = os.path.join(self.temp_mod_source_dir, 'diff.eio')
+        self.assertEqual(TextDifferences.EQUAL, SuiteRunner.diff_text_files(base_eio, mod_eio, diff_file))
+
     def test_eio_diff_with_utf8(self):
         base_eio = os.path.join(self.resources, 'eplusout_with_utf8_base.eio')
         mod_eio = os.path.join(self.resources, 'eplusout_with_utf8_mod.eio')


### PR DESCRIPTION
These are throwing an unnecessarily high number of diffs and muddying up potentially other changes, so just ignore the version number change in tables and EIOs (and IDFs).