### PR TITLE
Flake8 fixes

### DIFF
--- a/epregressions/runtests.py
+++ b/epregressions/runtests.py
@@ -223,10 +223,10 @@ class SuiteRunner:
                 break
         if has_sqlite_object:
             import re
-            RE_SQLITE = re.compile('Output:SQlite\s*,(?P<Option>[^,;]*?)\s*(?P<TabularUnitConv>,[^,;]*?\s*)?;',
+            RE_SQLITE = re.compile(r'Output:SQlite\s*,(?P<Option>[^,;]*?)\s*(?P<TabularUnitConv>,[^,;]*?\s*)?;',
                                    re.IGNORECASE)
             if force_output_sql_unitconv == ForceOutputSQLUnitConversion.NOFORCE:
-                idf_text = RE_SQLITE.sub('Output:SQLite,\n    {}\g<TabularUnitConv>;\n'.format(force_output_sql.value),
+                idf_text = RE_SQLITE.sub(r'Output:SQLite,\n    {}\g<TabularUnitConv>;\n'.format(force_output_sql.value),
                                          idf_text)
             else:
                 new_obj = '''Output:SQLite,
@@ -1106,7 +1106,7 @@ class SuiteRunner:
         else:  # for all other applications, run them in a multiprocessing pool
             p = Pool(self.number_of_threads)
             for run in diff_runs:
-                p.apply_async(self.diff_wrapper, (run, ), callback=self.diff_done, error_callback=self.diff_done)
+                p.apply_async(self.diff_wrapper, (run,), callback=self.diff_done, error_callback=self.diff_done)
             p.close()
             p.join()
 

--- a/epregressions/structures.py
+++ b/epregressions/structures.py
@@ -4,6 +4,7 @@ import json
 import os
 from enum import Enum
 
+
 class ForceRunType:
     DD = "Force Design-day-only simulations"
     ANNUAL = "Force Annual simulations"

--- a/epregressions/tests/test_runtests.py
+++ b/epregressions/tests/test_runtests.py
@@ -2397,5 +2397,3 @@ class TestSQLiteForce(unittest.TestCase):
         expected_data = {
             'Output:SQLite': {'Output:SQLite 4': {'option_type': 'SimpleAndTabular', 'unit_conversion': 'InchPound'}}}
         self.assertEqual(json.dumps(expected_data, indent=4), mod_text)
-
-


### PR DESCRIPTION
@jmarrec, flake8 was complaining about invalid escape sequences in the two regexes, saying that `\s` wouldn't be treated properly.  The recommendation was to make them a raw string so that it wouldn't be escaped, and would be passed to the regex compiler as-is.  Does that make sense to you?  I re-ran the unit test suite and it still passes, so maybe this isn't as much an error, but a warning.  Anyway, I'll hold this for now until you can :+1: or :-1: 

Thanks!