### PR TITLE
Fix package build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
       shell: bash
       run: pip install -r requirements.txt
 
+    - name: Install setuptools also
+      shell: bash
+      run: pip install setuptools
+
     - name: Build the Wheel
       shell: bash
       run: rm -rf dist/ build/ && python3 setup.py bdist_wheel sdist

--- a/energyplus_regressions/__init__.py
+++ b/energyplus_regressions/__init__.py
@@ -1,2 +1,2 @@
 NAME = 'energyplus_regressions'
-VERSION = '2.0.4'
+VERSION = '2.0.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ docutils   # pinning this because it breaks at 0.18
 wheel
 
 # for polishing up the Pip install
-PLAN-Tools==0.5
+PLAN-Tools>=0.5


### PR DESCRIPTION
Package build failed because setuptools is not available by default.  We can work that out later, for now, just pip install setuptools during packaging.