### PR TITLE
Updates for Python 3.12 and Boto3

### DIFF
--- a/energyplus_regressions/diffs/ci_compare_script.py
+++ b/energyplus_regressions/diffs/ci_compare_script.py
@@ -336,7 +336,7 @@ def main_function(file_name, base_dir, mod_dir, base_sha, mod_sha, _make_public,
                     index += f"""
                     <tr>
                       <td>{local_raw_file_name}</td>
-                      <td><a href='/{file_dir_once_uploaded}/{local_raw_file_name}'>download</a></td>
+                      <td><a href='/{file_dir_once_uploaded}/{local_raw_file_name}' download>download</a></td>
                       <td><a href='/{file_dir_once_uploaded}/{local_raw_file_name}.html'>view</a></td>
                     </tr>"""
                 index += """

--- a/energyplus_regressions/tests/diffs/test_ci_compare_script.py
+++ b/energyplus_regressions/tests/diffs/test_ci_compare_script.py
@@ -123,7 +123,7 @@ class TestCICompareScriptFunctions(unittest.TestCase):
                 mod_dir=self.temp_mod_dir,
                 base_sha='base123',
                 mod_sha='mod456',
-                make_public=True,
+                _make_public=True,
                 device_id='some_device_id',
                 test_mode=True
             )
@@ -148,7 +148,7 @@ class TestCICompareScriptFunctions(unittest.TestCase):
                 mod_dir=self.temp_mod_dir,
                 base_sha='base123',
                 mod_sha='mod456',
-                make_public=True,
+                _make_public=True,
                 device_id='some_device_id',
                 test_mode=True
             )
@@ -227,7 +227,7 @@ class TestCICompareScriptFunctions(unittest.TestCase):
                 mod_dir=self.temp_mod_dir,
                 base_sha='base124',
                 mod_sha='mod457',
-                make_public=True,
+                _make_public=True,
                 device_id='some_device_id',
                 test_mode=True
             )
@@ -279,7 +279,7 @@ class TestCICompareScriptFunctions(unittest.TestCase):
                 mod_dir=self.temp_mod_dir,
                 base_sha='base123',
                 mod_sha='mod456',
-                make_public=True,
+                _make_public=True,
                 device_id='some_device_id',
                 test_mode=True
             )
@@ -304,7 +304,7 @@ class TestCICompareScriptFunctions(unittest.TestCase):
                 mod_dir=self.temp_mod_dir,
                 base_sha='base123',
                 mod_sha='mod456',
-                make_public=True,
+                _make_public=True,
                 device_id='some_device_id',
                 test_mode=True
             )
@@ -369,7 +369,7 @@ class TestCICompareScriptFunctions(unittest.TestCase):
                 mod_dir=self.temp_mod_dir,
                 base_sha='base123',
                 mod_sha='mod456',
-                make_public=True,
+                _make_public=True,
                 device_id='some_device_id',
                 test_mode=False
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pypubsub
 beautifulsoup4
 
 # if running with CI, this is needed for talking to s3
-boto
+boto3
 
 # for running tests
 coveralls


### PR DESCRIPTION
Shift to boto3 as part of the Python 3.12 conversion.  Cleaned up posting code and accompanying unit tests as needed.