### PR TITLE
Fix BeautifulSoup4 Args Issue by pinning back to the previous version

### DIFF
--- a/energyplus_regressions/__init__.py
+++ b/energyplus_regressions/__init__.py
@@ -1,2 +1,2 @@
 NAME = 'energyplus_regressions'
-VERSION = '2.1.0'
+VERSION = '2.1.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # the core dependencies actually needed
 pypubsub
-beautifulsoup4
+beautifulsoup4==4.12.3
 
 # for running tests
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open(os.path.join(this_dir, 'README.md'), encoding='utf-8') as i_fil
     long_description = i_file.read()
 
 
-install_requires = ['PyPubSub', 'beautifulsoup4', 'PLAN-Tools>=0.5']
+install_requires = ['PyPubSub', 'beautifulsoup4==4.12.3', 'PLAN-Tools>=0.5']
 if system() == 'Windows':
     install_requires.append('pypiwin32')
 


### PR DESCRIPTION
Regressions were failing over on [E+](https://github.com/NREL/EnergyPlus/pull/10920) due to a release of BeautifulSoup4 from 6 hours ago.  Pinning to the previous version and things should be good again.