### PR TITLE
Adds build type preference selection and tablediff case insensitivity

### DIFF
--- a/energyplus_regressions/__init__.py
+++ b/energyplus_regressions/__init__.py
@@ -1,2 +1,2 @@
 NAME = 'energyplus_regressions'
-VERSION = '2.1.2'
+VERSION = '2.1.3'

--- a/energyplus_regressions/builds/base.py
+++ b/energyplus_regressions/builds/base.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Optional, Set
 
+from energyplus_regressions.structures import ConfigType
+
 
 class KnownBuildTypes:
     Makefile = "makefile"
@@ -87,10 +89,10 @@ class BaseBuildDirectoryStructure(object):
         filtered_list = filter(should_keep, all_idfs_relative_path)
         return set(filtered_list)
 
-    def set_build_directory(self, build_directory: Path):
+    def set_build_directory(self, build_directory: Path) -> None:
         raise NotImplementedError('Must implement set_build_directory(str) in derived classes')
 
-    def verify(self):
+    def verify(self) -> list[tuple[str, Path, bool]]:
         results: list[tuple[str, Path, bool]] = []
         if not self.build_directory:
             raise Exception('Build directory has not been set with set_build_directory()')
@@ -140,5 +142,5 @@ class BaseBuildDirectoryStructure(object):
     def get_build_tree(self) -> BuildTree:
         raise NotImplementedError('Must implement get_build_tree() in derived classes')
 
-    def get_idf_directory(self):
+    def get_idf_directory(self) -> Path:
         raise NotImplementedError()

--- a/energyplus_regressions/builds/base.py
+++ b/energyplus_regressions/builds/base.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import Optional, Set
 
-from energyplus_regressions.structures import ConfigType
-
 
 class KnownBuildTypes:
     Makefile = "makefile"

--- a/energyplus_regressions/builds/install.py
+++ b/energyplus_regressions/builds/install.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from energyplus_regressions.builds.base import BaseBuildDirectoryStructure, BuildTree
 from energyplus_regressions.ep_platform import exe_extension
-from energyplus_regressions.structures import ConfigType
 
 
 class EPlusInstallDirectory(BaseBuildDirectoryStructure):

--- a/energyplus_regressions/builds/install.py
+++ b/energyplus_regressions/builds/install.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from energyplus_regressions.builds.base import BaseBuildDirectoryStructure, BuildTree
 from energyplus_regressions.ep_platform import exe_extension
+from energyplus_regressions.structures import ConfigType
 
 
 class EPlusInstallDirectory(BaseBuildDirectoryStructure):
@@ -21,7 +22,7 @@ class EPlusInstallDirectory(BaseBuildDirectoryStructure):
         # For an E+ install, the source directory is kinda just the root repo
         self.source_directory = build_directory
 
-    def get_idf_directory(self):
+    def get_idf_directory(self) -> Path:
         if not self.build_directory:
             raise Exception('Build directory has not been set with set_build_directory()')
         return self.source_directory / 'ExampleFiles'

--- a/energyplus_regressions/builds/makefile.py
+++ b/energyplus_regressions/builds/makefile.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from energyplus_regressions.builds.base import BaseBuildDirectoryStructure, BuildTree
 from energyplus_regressions.ep_platform import exe_extension
+from energyplus_regressions.structures import ConfigType
 
 
 class CMakeCacheMakeFileBuildDirectory(BaseBuildDirectoryStructure):
@@ -30,7 +31,7 @@ class CMakeCacheMakeFileBuildDirectory(BaseBuildDirectoryStructure):
             else:
                 raise Exception('Could not find source directory spec in the CMakeCache file')
 
-    def get_idf_directory(self):
+    def get_idf_directory(self) -> Path:
         if not self.build_directory:
             raise Exception('Build directory has not been set with set_build_directory()')
         return self.source_directory / 'testfiles'

--- a/energyplus_regressions/builds/makefile.py
+++ b/energyplus_regressions/builds/makefile.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from energyplus_regressions.builds.base import BaseBuildDirectoryStructure, BuildTree
 from energyplus_regressions.ep_platform import exe_extension
-from energyplus_regressions.structures import ConfigType
 
 
 class CMakeCacheMakeFileBuildDirectory(BaseBuildDirectoryStructure):

--- a/energyplus_regressions/builds/visualstudio.py
+++ b/energyplus_regressions/builds/visualstudio.py
@@ -80,12 +80,3 @@ class CMakeCacheVisualStudioBuildDirectory(BaseBuildDirectoryStructure):
         b.weather_dir = self.source_directory / 'weather'
         b.data_sets_dir = self.source_directory / 'datasets'
         return b
-
-    def verify(self) -> list[tuple[str, Path, bool]]:
-        desired_build_directory = self.build_directory / 'Products' / self.build_mode
-        full_results = list()
-        full_results.append(
-            ("Case %s Build Mode Directory Exists? ", desired_build_directory, desired_build_directory.exists())
-        )
-        base_results = super().verify()
-        return full_results + base_results

--- a/energyplus_regressions/builds/visualstudio.py
+++ b/energyplus_regressions/builds/visualstudio.py
@@ -80,3 +80,12 @@ class CMakeCacheVisualStudioBuildDirectory(BaseBuildDirectoryStructure):
         b.weather_dir = self.source_directory / 'weather'
         b.data_sets_dir = self.source_directory / 'datasets'
         return b
+
+    def verify(self) -> list[tuple[str, Path, bool]]:
+        desired_build_directory = self.build_directory / 'Products' / self.build_mode
+        full_results = list()
+        full_results.append(
+            ("Case %s Build Mode Directory Exists? ", desired_build_directory, desired_build_directory.exists())
+        )
+        base_results = super().verify()
+        return full_results + base_results

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -121,8 +121,12 @@ def thresh_abs_rel_diff(abs_thresh, rel_thresh, x, y):
         # else:
         #     diff = 'equal'
         return abs_diff, rel_diff, diff
-    except:
-        return '%s vs %s' % (x, y), '%s vs %s' % (x, y), 'stringdiff'
+    except ValueError:
+        # if we couldn't get a float out of it, we are doing string comparison, check case-insensitively before leaving
+        if x.lower().strip() == y.lower().strip():
+            return 0, 0, 'equal'
+        else:
+            return '%s vs %s' % (x, y), '%s vs %s' % (x, y), 'stringdiff'
 
 
 def prev_sib(entity):

--- a/energyplus_regressions/energyplus.py
+++ b/energyplus_regressions/energyplus.py
@@ -104,7 +104,8 @@ def execute_energyplus(e_args: ExecutionArguments) -> tuple[Path, str, bool, boo
         # Run ExpandObjects and process as necessary, but not for epJSON files!
         if idf_file.exists():
             expand_objects_run = subprocess.Popen(
-                str(expand_objects), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                str(expand_objects), shell=True, stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             o, e = expand_objects_run.communicate()
             std_out += o

--- a/energyplus_regressions/runtests.py
+++ b/energyplus_regressions/runtests.py
@@ -43,7 +43,7 @@ class TestRunConfiguration:
 
     def __init__(self, force_run_type: str, num_threads: int, report_freq: str,
                  build_a: BaseBuildDirectoryStructure, build_b: BaseBuildDirectoryStructure,
-                 single_test_run: bool=False, force_output_sql: ForceOutputSQL = ForceOutputSQL.NOFORCE,
+                 single_test_run: bool = False, force_output_sql: ForceOutputSQL = ForceOutputSQL.NOFORCE,
                  force_output_sql_unitconv: ForceOutputSQLUnitConversion = ForceOutputSQLUnitConversion.NOFORCE):
         self.force_run_type = force_run_type
         self.TestOneFile = single_test_run

--- a/energyplus_regressions/runtests.py
+++ b/energyplus_regressions/runtests.py
@@ -17,7 +17,7 @@ else:
 
 from difflib import unified_diff  # python's own diff library
 
-from energyplus_regressions.builds.base import BuildTree
+from energyplus_regressions.builds.base import BuildTree, BaseBuildDirectoryStructure
 from energyplus_regressions.diffs import math_diff, table_diff, thresh_dict as td
 from energyplus_regressions.energyplus import ExecutionArguments, execute_energyplus
 from energyplus_regressions.structures import (
@@ -41,8 +41,9 @@ script_dir = Path(__file__).resolve().parent
 class TestRunConfiguration:
     __test__ = False  # so that PyTest doesn't try to run this as a class fixture
 
-    def __init__(self, force_run_type, num_threads, report_freq, build_a, build_b, single_test_run=False,
-                 force_output_sql: ForceOutputSQL = ForceOutputSQL.NOFORCE,
+    def __init__(self, force_run_type: str, num_threads: int, report_freq: str,
+                 build_a: BaseBuildDirectoryStructure, build_b: BaseBuildDirectoryStructure,
+                 single_test_run: bool=False, force_output_sql: ForceOutputSQL = ForceOutputSQL.NOFORCE,
                  force_output_sql_unitconv: ForceOutputSQLUnitConversion = ForceOutputSQLUnitConversion.NOFORCE):
         self.force_run_type = force_run_type
         self.TestOneFile = single_test_run
@@ -57,7 +58,7 @@ class TestRunConfiguration:
 class TestCaseCompleted:
     __test__ = False  # so that PyTest doesn't try to run this as a class fixture
 
-    def __init__(self, run_directory, case_name, run_status, error_msg_reported_already, extra_message=""):
+    def __init__(self, run_directory: str, case_name: str, run_status, error_msg_reported_already, extra_message=""):
         self.run_directory = run_directory
         self.case_name = case_name
         self.run_success = run_status
@@ -68,7 +69,7 @@ class TestCaseCompleted:
 # the actual main test suite run class
 class SuiteRunner:
 
-    def __init__(self, run_config, these_entries, mute=False):
+    def __init__(self, run_config: TestRunConfiguration, these_entries, mute=False):
 
         # initialize the master mute button -- this is overridden by registering callbacks
         self.mute = mute
@@ -446,7 +447,7 @@ class SuiteRunner:
                     local_run_type,
                     self.min_reporting_freq,
                     parametric_file,
-                    epw_path
+                    str(epw_path)
                 )
             )
 

--- a/energyplus_regressions/structures.py
+++ b/energyplus_regressions/structures.py
@@ -52,6 +52,11 @@ class ForceOutputSQLUnitConversion(Enum):
     InchPound = 'InchPound'
 
 
+class ConfigType(Enum):
+    RELEASE = "Release"
+    DEBUG = "Debug"
+
+
 class Results:
     def __init__(self):
         self.descriptions = {}

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_has_string_diff_case_only.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_has_string_diff_case_only.htm
@@ -1,0 +1,100 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">       hello</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Net Conditioned Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Unconditioned Building Area</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -194,6 +194,27 @@ class TestTableDiff(unittest.TestCase):
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
         self.assertEqual(0, response[8])  # in file 1 but not in file 2
 
+    def test_string_diff_case_change_only(self):
+        # should be no diffs for case-insensitive comparison
+        response = table_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplustbl_has_string_diff_base.htm'),
+            os.path.join(self.diff_files_dir, 'eplustbl_has_string_diff_case_only.htm'),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(3, response[1])  # count_of_tables
+        self.assertEqual(0, response[2])  # big diffs
+        self.assertEqual(0, response[3])  # small diffs
+        self.assertEqual(17, response[4])  # equals
+        self.assertEqual(0, response[5])  # string diffs
+        self.assertEqual(0, response[6])  # size errors
+        self.assertEqual(0, response[7])  # in file 2 but not in file 1
+        self.assertEqual(0, response[8])  # in file 1 but not in file 2
+
     def test_malformed_table_heading_in_file_1(self):
         response = table_diff(
             self.thresh_dict,

--- a/energyplus_regressions/tk_window.py
+++ b/energyplus_regressions/tk_window.py
@@ -1068,6 +1068,7 @@ class MyApp(Frame):
             return
         ok_or_cancel_msg = "Press OK to continue anyway (risky!), or press Cancel to abort"
         build_1_valid = self.build_1.verify()
+        print(build_1_valid)
         build_1_problem_files = [str(b[1]) for b in build_1_valid if not b[2]]
         if len(build_1_problem_files):
             missing_files = '\n'.join(build_1_problem_files)

--- a/energyplus_regressions/tk_window.py
+++ b/energyplus_regressions/tk_window.py
@@ -499,14 +499,14 @@ class MyApp(Frame):
             status = self.try_to_set_build_1_to_dir(Path(data['build_1_build_dir']), init_mode=True)
             if status:
                 self.build_dir_1_var.set(data['build_1_build_dir'])
-                if isinstance(self.build_1, CMakeCacheVisualStudioBuildDirectory):
-                    self.build_1.set_build_mode(ConfigType(self.preferred_build_type.get()))
+                # if isinstance(self.build_1, CMakeCacheVisualStudioBuildDirectory):
+                #     self.build_1.set_build_mode(ConfigType(self.preferred_build_type.get()))
             # try to set build 2 object, where it will try to use the preferred build type
             status = self.try_to_set_build_2_to_dir(Path(data['build_2_build_dir']), init_mode=True)
             if status:
                 self.build_dir_2_var.set(data['build_2_build_dir'])
-                if isinstance(self.build_2, CMakeCacheVisualStudioBuildDirectory):
-                    self.build_2.set_build_mode(ConfigType(self.preferred_build_type.get()))
+                # if isinstance(self.build_2, CMakeCacheVisualStudioBuildDirectory):
+                #     self.build_2.set_build_mode(ConfigType(self.preferred_build_type.get()))
             # at this point we should have build dirs, but it's OK if they are invalid
             self.build_idf_listing(False, data['idfs'])
             self.add_to_log("Project settings loaded")

--- a/energyplus_regressions/tk_window.py
+++ b/energyplus_regressions/tk_window.py
@@ -499,14 +499,10 @@ class MyApp(Frame):
             status = self.try_to_set_build_1_to_dir(Path(data['build_1_build_dir']), init_mode=True)
             if status:
                 self.build_dir_1_var.set(data['build_1_build_dir'])
-                # if isinstance(self.build_1, CMakeCacheVisualStudioBuildDirectory):
-                #     self.build_1.set_build_mode(ConfigType(self.preferred_build_type.get()))
             # try to set build 2 object, where it will try to use the preferred build type
             status = self.try_to_set_build_2_to_dir(Path(data['build_2_build_dir']), init_mode=True)
             if status:
                 self.build_dir_2_var.set(data['build_2_build_dir'])
-                # if isinstance(self.build_2, CMakeCacheVisualStudioBuildDirectory):
-                #     self.build_2.set_build_mode(ConfigType(self.preferred_build_type.get()))
             # at this point we should have build dirs, but it's OK if they are invalid
             self.build_idf_listing(False, data['idfs'])
             self.add_to_log("Project settings loaded")
@@ -1068,7 +1064,8 @@ class MyApp(Frame):
             return
         ok_or_cancel_msg = "Press OK to continue anyway (risky!), or press Cancel to abort"
         build_1_valid = self.build_1.verify()
-        print(build_1_valid)
+        if isinstance(self.build_1, CMakeCacheVisualStudioBuildDirectory):
+            self.build_1.set_build_mode(ConfigType(self.preferred_build_type.get()), self.add_to_log_and_alert)
         build_1_problem_files = [str(b[1]) for b in build_1_valid if not b[2]]
         if len(build_1_problem_files):
             missing_files = '\n'.join(build_1_problem_files)
@@ -1079,6 +1076,8 @@ class MyApp(Frame):
             messagebox.showerror("Build folder 2 problem", "Select a valid build folder 2 prior to running")
             return
         build_2_valid = self.build_2.verify()
+        if isinstance(self.build_2, CMakeCacheVisualStudioBuildDirectory):
+            self.build_2.set_build_mode(ConfigType(self.preferred_build_type.get()), self.add_to_log_and_alert)
         build_2_problem_files = [str(b[1]) for b in build_2_valid if not b[2]]
         if len(build_2_problem_files):
             missing_files = '\n'.join(build_2_problem_files)

--- a/energyplus_regressions/tk_window.py
+++ b/energyplus_regressions/tk_window.py
@@ -503,7 +503,6 @@ class MyApp(Frame):
                 #     self.build_1.set_build_mode(ConfigType(self.preferred_build_type.get()))
             # try to set build 2 object, where it will try to use the preferred build type
             status = self.try_to_set_build_2_to_dir(Path(data['build_2_build_dir']), init_mode=True)
-            print("B")
             if status:
                 self.build_dir_2_var.set(data['build_2_build_dir'])
                 # if isinstance(self.build_2, CMakeCacheVisualStudioBuildDirectory):
@@ -690,7 +689,6 @@ class MyApp(Frame):
                     return
             if not self.build_2:
                 bd2 = Path(self.build_dir_2_var.get())
-                print("C")
                 status = self.try_to_set_build_2_to_dir(bd2)
                 if not status:
                     self.full_idf_listbox.insert(END, "Cannot update master list master list")
@@ -972,7 +970,6 @@ class MyApp(Frame):
 
     def refresh_builds_for_build_type_change(self, *_):
         # just try to refresh both build directories, it will warn if the debug/release folders aren't there
-        print("A")
         self.try_to_set_build_1_to_dir(self.build_1.build_directory)
         self.try_to_set_build_2_to_dir(self.build_2.build_directory)
 
@@ -1049,7 +1046,6 @@ class MyApp(Frame):
         p = Path(selected_dir)
         if not p.exists():
             return
-        print("D")
         status = self.try_to_set_build_2_to_dir(p)
         if not status:
             messagebox.showerror("Could not determine build type for build 2!")

--- a/energyplus_regressions/tk_window.py
+++ b/energyplus_regressions/tk_window.py
@@ -503,6 +503,7 @@ class MyApp(Frame):
                 #     self.build_1.set_build_mode(ConfigType(self.preferred_build_type.get()))
             # try to set build 2 object, where it will try to use the preferred build type
             status = self.try_to_set_build_2_to_dir(Path(data['build_2_build_dir']), init_mode=True)
+            print("B")
             if status:
                 self.build_dir_2_var.set(data['build_2_build_dir'])
                 # if isinstance(self.build_2, CMakeCacheVisualStudioBuildDirectory):
@@ -689,6 +690,7 @@ class MyApp(Frame):
                     return
             if not self.build_2:
                 bd2 = Path(self.build_dir_2_var.get())
+                print("C")
                 status = self.try_to_set_build_2_to_dir(bd2)
                 if not status:
                     self.full_idf_listbox.insert(END, "Cannot update master list master list")
@@ -970,6 +972,7 @@ class MyApp(Frame):
 
     def refresh_builds_for_build_type_change(self, *_):
         # just try to refresh both build directories, it will warn if the debug/release folders aren't there
+        print("A")
         self.try_to_set_build_1_to_dir(self.build_1.build_directory)
         self.try_to_set_build_2_to_dir(self.build_2.build_directory)
 
@@ -1046,6 +1049,7 @@ class MyApp(Frame):
         p = Path(selected_dir)
         if not p.exists():
             return
+        print("D")
         status = self.try_to_set_build_2_to_dir(p)
         if not status:
             messagebox.showerror("Could not determine build type for build 2!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pypubsub
 beautifulsoup4==4.12.3
 
 # for running tests
+coverage
 coveralls
 flake8
 pytest


### PR DESCRIPTION
- We had a request to loosen up tablediff and allow it to compare strings in the column data in a case insensitive manner.  So that's done here.  Unit test added, minor cleanups along the way.
- We also had a request to allow requesting either debug or release build configuration as a preference from the main window.  I added a dropdown so you can select which you prefer.  If the folder doesn't exist (yet) it will try to set it...then if you go ahead and run, the validation script should alert you that your build folder doesn't exist.  I'm open to suggestions to improve the workflow and user experience here.