### PR TITLE
Allow some table reordering and ignoring

### DIFF
--- a/energyplus_regressions/__init__.py
+++ b/energyplus_regressions/__init__.py
@@ -1,2 +1,2 @@
 NAME = 'energyplus_regressions'
-VERSION = '2.1.3'
+VERSION = '2.1.4'

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -474,9 +474,20 @@ def table_diff(
                                table_not_in_1, table_not_in_2)
             continue
 
+        # create a list of order-dependent table uhedaings, these will not use the special row order independence code
+        row_order_dependent_tables = [
+            ' FullName:Climatic Data Summary_Entire Facility_Monthly Precipitation Summary'
+        ]
+
+        # always process the first table into a base hdict
         hdict1, horder1 = table2hdict_horder(table1)
 
-        hdict2, horder2 = table2hdict_horder(table2, table1)
+        # if we are in a row order dependent table, don't pass table1 as a baseline, just use the literal in-place order
+        if uheading1 in row_order_dependent_tables:
+            hdict2, horder2 = table2hdict_horder(table2)
+        # but for all other tables, we can use the first table as a baseline to carefully match up the rows
+        else:
+            hdict2, horder2 = table2hdict_horder(table2, table1)
 
         # honestly, if the column headings have changed, this should be an indicator to all reviewers that this needs
         # up close investigation.  As such, we are going to trigger the following things:

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -258,7 +258,8 @@ def table2hdict_horder(table, table_a=None):
             for tcol in trow('td'):
                 if tcol.contents:
                     search_key.append(tcol.contents[0])
-                else:
+                else:  # pragma: no cover
+                    # I really don't think we can make it here while searching, but I don't want to accidentally crash
                     search_key.append("")
             table_a_row_order.append(search_key)
         # process the rows of the "mod" table that was provided into a list of search keys
@@ -268,7 +269,8 @@ def table2hdict_horder(table, table_a=None):
             for tcol in trow('td'):
                 if tcol.contents:
                     search_key.append(tcol.contents[0])
-                else:
+                else:  # pragma: no cover
+                    # I really don't think we can make it here while searching, but I don't want to accidentally crash
                     search_key.append("")
             found_table_b_row_order.append(search_key)
         # it's the same order exactly, skip any searching and just run with search_rows as-is

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 """Takes two E+ html output files and compares them
 usage:
@@ -36,6 +34,7 @@ __version__ = "1.4"
 __copyright__ = "Copyright (c) 2009 Santosh Philip and Amir Roth 2013"
 __license__ = "GNU General Public License Version 3"
 
+from pathlib import Path
 import sys
 import getopt
 import os.path
@@ -45,8 +44,8 @@ from energyplus_regressions.diffs.thresh_dict import ThreshDict
 
 help_message = __doc__
 
-path = os.path.dirname(__file__)
-script_dir = os.path.abspath(path)
+this_file = Path(__file__).resolve()
+script_dir = this_file.parent
 
 title_css = """<!DOCTYPE html PUBLIC "-
 //W3C//DTD XHTML 1.0 Strict//EN"
@@ -95,38 +94,26 @@ td.table_size_error {
 """
 
 
-def thresh_abs_rel_diff(abs_thresh, rel_thresh, x, y):
+def thresh_abs_rel_diff(abs_thresh: float, rel_thresh: float, x: str, y: str) -> tuple[float | str, float | str, str]:
     if x == y:
         return 0, 0, 'equal'
-    # noinspection PyBroadException
     try:
-        diff = 'equal'
-
         fx = float(x)
         fy = float(y)
-
         abs_diff = abs(fx - fy)
-
-        # the following two lines were here, but I don't see how they could be hit, I'm commenting for now
-        # if abs_diff == 0.0:
-        #     return 0, 0, 'equal'
-
         rel_diff = abs((fx - fy) / fx) if abs(fx) > abs(fy) else abs((fy - fx) / fy)
-
+        diff = 'equal'
         if abs_diff > abs_thresh and rel_diff > rel_thresh:
             diff = 'big'
         elif (0 < abs_diff <= abs_thresh) or (0 < rel_diff <= rel_thresh):
             diff = 'small'
-        # the following else clause was here, but again, I don't see how it could be hit, commenting
-        # else:
-        #     diff = 'equal'
         return abs_diff, rel_diff, diff
     except ValueError:
         # if we couldn't get a float out of it, we are doing string comparison, check case-insensitively before leaving
         if x.lower().strip() == y.lower().strip():
             return 0, 0, 'equal'
         else:
-            return '%s vs %s' % (x, y), '%s vs %s' % (x, y), 'stringdiff'
+            return f'{x} vs {y}', f'{x} vs {y}', 'stringdiff'
 
 
 def prev_sib(entity):
@@ -235,7 +222,8 @@ def hdict2soup(soup, heading, num, hdict, tdict, horder):
 
 
 # Convert html table to heading dictionary (and header list) in single step
-def table2hdict_horder(table):
+def table2hdict_horder(table, table_a_hdict=None):
+    # If table_a_hdict is passed in, we can try to match the row order to avoid diffs just due to row order
     hdict = {}
     horder = []
     trows = table('tr')
@@ -250,7 +238,26 @@ def table2hdict_horder(table):
         hdict[hcontents] = []
         horder.append(hcontents)
 
-    for trow in trows[1:]:
+    search_rows = trows[1:]
+
+    # Handle it specially if we passed in table_a's hdict and it's just a valid reorder
+    if table_a_hdict:
+        if 'DummyPlaceholder' in table_a_hdict:
+            table_a_row_order = table_a_hdict['DummyPlaceholder']
+            found_table_b_row_order = []
+            for trow in trows[1:]:
+                found_table_b_row_order.append(trow('td')[0].contents[0])
+            if sorted(table_a_row_order) == sorted(found_table_b_row_order):  # we have the same values, maybe reordered
+                # now just build the list of trows to search by index based on table a order
+                search_rows = []
+                for to_find_val in table_a_row_order:
+                    for trow in trows[1:]:
+                        for td in trow('td'):
+                            this_val = td.contents[0]
+                            if this_val == to_find_val:
+                                search_rows.append(trow)
+
+    for trow in search_rows:
         for htd, td in zip(trows[0]('td'), trow('td')):
             try:
                 hcontents = htd.contents[0]
@@ -317,7 +324,10 @@ def make_err_table_row(err_soup, tabletag, uheading, count_of_tables, abs_diff_f
         'size mismatch' if size_error > 0 else 'not in 1' if not_in_1 > 0 else 'not in 2' if not_in_2 > 0 else '')
 
 
-def table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file, err_file, summary_file):
+def table_diff(
+        thresh_dict: ThreshDict, input_file_1: str, input_file_2: str, abs_diff_file: str,
+        rel_diff_file: str, err_file: str, summary_file: str
+):
     """
     Compares two xxxTable.html files returning
     (
@@ -326,32 +336,31 @@ def table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file
         <#size_diff>, <#not_in_file1>, <#not_in_file2>
     )
     """
+    file_1 = Path(input_file_1)
+    file_2 = Path(input_file_2)
 
-    case_name = inputfile1.split(os.sep)[-2]
+    case_name = file_1.parent.name
 
     # Test for existence of input files
-    if not os.path.exists(inputfile1):
-        return 'unable to open file <%s>' % inputfile1, 0, 0, 0, 0, 0, 0, 0, 0
-    if not os.path.exists(inputfile2):
-        return 'unable to open file <%s>' % inputfile2, 0, 0, 0, 0, 0, 0, 0, 0
+    if not file_1.exists():
+        return 'unable to open file <%s>' % input_file_1, 0, 0, 0, 0, 0, 0, 0, 0
+    if not file_2.exists():
+        return 'unable to open file <%s>' % input_file_2, 0, 0, 0, 0, 0, 0, 0, 0
 
-    with open(inputfile1, 'rb') as f_1:
-        txt1 = f_1.read().decode('utf-8', errors='ignore')
-    with open(inputfile2, 'rb') as f_2:
-        txt2 = f_2.read().decode('utf-8', errors='ignore')
+    txt1 = file_1.read_text()
+    txt2 = file_2.read_text()
 
-    pagetitle = '%s vs %s' % (os.path.basename(inputfile1), os.path.basename(inputfile2))
+    page_title = f'{file_1.name} vs {file_2.name}'
 
     # Error soup
-    err_soup = BeautifulSoup(title_css % (pagetitle + ' -- summary', the_css,),
-                             features='html.parser')
+    err_soup = BeautifulSoup(title_css % (page_title + ' -- summary', the_css,), features='html.parser')
 
     # Abs diff soup
-    abs_diff_soup = BeautifulSoup(title_css % (pagetitle + ' -- absolute differences', the_css,),
+    abs_diff_soup = BeautifulSoup(title_css % (page_title + ' -- absolute differences', the_css,),
                                   features='html.parser')
 
     # Rel diff soup
-    rel_diff_soup = BeautifulSoup(title_css % (pagetitle + ' -- relative differences', the_css,),
+    rel_diff_soup = BeautifulSoup(title_css % (page_title + ' -- relative differences', the_css,),
                                   features='html.parser')
 
     # Make error table
@@ -381,9 +390,9 @@ def table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file
         uheadings2.append(get_table_unique_heading(table))
 
     if any([x is None for x in uheadings1]):
-        return 'malformed comment/table structure in <%s>' % inputfile1, 0, 0, 0, 0, 0, 0, 0, 0
+        return 'malformed comment/table structure in <%s>' % input_file_1, 0, 0, 0, 0, 0, 0, 0, 0
     if any([x is None for x in uheadings2]):
-        return 'malformed comment/table structure in <%s>' % inputfile2, 0, 0, 0, 0, 0, 0, 0, 0
+        return 'malformed comment/table structure in <%s>' % input_file_2, 0, 0, 0, 0, 0, 0, 0, 0
 
     uhset1 = set(uheadings1)
     uhset2 = set(uheadings2)
@@ -436,7 +445,7 @@ def table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file
             continue
 
         hdict1, horder1 = table2hdict_horder(table1)
-        hdict2, horder2 = table2hdict_horder(table2)
+        hdict2, horder2 = table2hdict_horder(table2, hdict1)
 
         # honestly, if the column headings have changed, this should be an indicator to all reviewers that this needs
         # up close investigation.  As such, we are going to trigger the following things:
@@ -556,7 +565,7 @@ def table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file
             count_of_size_error, count_of_not_in_1, count_of_not_in_2)
 
 
-def main(argv=None):  # pragma: no cover
+def main(argv=None) -> int:  # pragma: no cover
     if argv is None:
         argv = sys.argv
     try:
@@ -565,19 +574,9 @@ def main(argv=None):  # pragma: no cover
         print(sys.argv[0].split("/")[-1] + ": " + str(msg) + "\n\t for help use --help")
         return -1
 
-    # Test for correct number of arguments
-    # prog_name = os.path.basename(sys.argv[0])
-    # if len(args) == 5:
-    [inputfile1, inputfile2, abs_diff_file, rel_diff_file, err_file, summary_file] = args
-    # else:
-    #    info('%s: incorrect operands: Try %s -h for more info' % (prog_name, prog_name))
-    #    return -1
-
-    # Load diffing threshold dictionary
+    [input_file_1, input_file_2, abs_diff_file, rel_diff_file, err_file, summary_file] = args
     thresh_dict = ThreshDict(os.path.join(script_dir, 'math_diff.config'))
-
-    # run the main program.
-    table_diff(thresh_dict, inputfile1, inputfile2, abs_diff_file, rel_diff_file, err_file, summary_file)
+    table_diff(thresh_dict, input_file_1, input_file_2, abs_diff_file, rel_diff_file, err_file, summary_file)
     return 0
 
 

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -474,16 +474,15 @@ def table_diff(
                                table_not_in_1, table_not_in_2)
             continue
 
-        # create a list of order-dependent table uhedaings, these will not use the special row order independence code
-        row_order_dependent_tables = [
-            ' FullName:Climatic Data Summary_Entire Facility_Monthly Precipitation Summary'
-        ]
+        # create a list of order-dependent table uheading keys, tables that include these keys in the name
+        # these will use strict row order enforcement
+        row_order_dependent_table_keys = ['Monthly', 'Topology']
 
         # always process the first table into a base hdict
         hdict1, horder1 = table2hdict_horder(table1)
 
         # if we are in a row order dependent table, don't pass table1 as a baseline, just use the literal in-place order
-        if uheading1 in row_order_dependent_tables:
+        if any(k in uheading1 for k in row_order_dependent_table_keys):
             hdict2, horder2 = table2hdict_horder(table2)
         # but for all other tables, we can use the first table as a baseline to carefully match up the rows
         else:

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -453,6 +453,14 @@ def table_diff(
 
         uheading1 = uheadings1[i1]
 
+        # There are some (for now one) tables that we will want to skip entirely because they are not useful for
+        # throwing regressions, add search keys to this list to skip them
+        completely_skippable_table_keys = [
+            'Object Count Summary_Entire Facility_Input Fields'
+        ]
+        if any([x in uheading1 for x in completely_skippable_table_keys]):
+            continue
+
         # Table missing in second input file
         if uheading1 not in uhset_match:
             table_not_in_2 = 1

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_base.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_base.htm
@@ -96,7 +96,114 @@
     <td align="right">21-DEC-07:15</td>
   </tr>
 </table>
-<div class="footnote" style="font-style: italic;">Values shown are for all completed run periods - including any simulations run during sizing periods</div>
+<br><br>
+<b>Monthly Precipitation Summary</b><br><br>
+<!-- FullName:Climatic Data Summary_Entire Facility_Monthly Precipitation Summary-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Monthly Total Precipitation from .epw [mm]</td>
+    <td align="right">Monthly Total Hours of Rain from .epw</td>
+    <td align="right">Monthly Total Precipitation in Site:Precipitation [mm]</td>
+    <td align="right">Monthly Total Roof Irrigation Depth [mm]</td>
+    <td align="right">Monthly Total Rain Collection Volume [m3]</td>
+  </tr>
+  <tr>
+    <td align="right">Jan</td>
+    <td align="right">       0.20</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Feb</td>
+    <td align="right">       0.10</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Mar</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Apr</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">May</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Jun</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Jul</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Aug</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Sep</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Oct</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Nov</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Dec</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+</table>
 <br><br>
 </body>
 </html>

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_base.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_base.htm
@@ -1,0 +1,102 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html lang="">
+<head>
+<title> OutPatientHealthCare RUNPERIOD 3 ** Denver-Aurora-Buckley AFB CO USA TMY3 WMO#=724695
+  2025-05-15
+  09:19:23
+ - EnergyPlus</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 25.2.0-1d1af7dd68, YMD=2025.05.15 09:19</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>OutPatientHealthCare</b></p>
+<p>Environment: <b>RUNPERIOD 3 ** Denver-Aurora-Buckley AFB CO USA TMY3 WMO#=724695</b></p>
+<p>Simulation Timestamp: <b>2025-05-15
+  09:19:23</b></p>
+<hr>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2025-05-15
+    09:19:23</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<a name=EnergyMeters::EntireFacility></a>
+<p>Report:<b> Energy Meters</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2025-05-15
+    09:19:23</b></p>
+<b>Annual and Peak Values - Electricity</b><br><br>
+<!-- FullName:Energy Meters_Entire Facility_Annual and Peak Values - Electricity-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Electricity Annual Value [GJ]</td>
+    <td align="right">Electricity Minimum Value [W]</td>
+    <td align="right">Timestamp of Minimum {TIMESTAMP}</td>
+    <td align="right">Electricity Maximum Value [W]</td>
+    <td align="right">Timestamp of Maximum {TIMESTAMP}</td>
+  </tr>
+  <tr>
+    <td align="right">ElectricityNet:Plant</td>
+    <td align="right">      25.58</td>
+    <td align="right">   79056.27</td>
+    <td align="right">21-DEC-20:15</td>
+    <td align="right">  247648.40</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">Cogeneration:ElectricityNet</td>
+    <td align="right">      25.58</td>
+    <td align="right">   79056.27</td>
+    <td align="right">21-DEC-20:15</td>
+    <td align="right">  247648.40</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">General:Cogeneration:ElectricityNet</td>
+    <td align="right">      25.58</td>
+    <td align="right">   79056.27</td>
+    <td align="right">21-DEC-20:15</td>
+    <td align="right">  247648.40</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity:HVAC</td>
+    <td align="right">      12.30</td>
+    <td align="right">   30407.24</td>
+    <td align="right">21-JUL-04:15</td>
+    <td align="right">  173684.04</td>
+    <td align="right">21-DEC-07:15</td>
+  </tr>
+  <tr>
+    <td align="right">Fans:Electricity</td>
+    <td align="right">       2.36</td>
+    <td align="right">    6859.41</td>
+    <td align="right">21-DEC-00:30</td>
+    <td align="right">   32834.85</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">General:Fans:Electricity</td>
+    <td align="right">       2.36</td>
+    <td align="right">    6859.41</td>
+    <td align="right">21-DEC-00:30</td>
+    <td align="right">   32834.85</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">Heating:Electricity</td>
+    <td align="right">       4.43</td>
+    <td align="right">       0.00</td>
+    <td align="right">21-JUL-00:15</td>
+    <td align="right">  140841.61</td>
+    <td align="right">21-DEC-07:15</td>
+  </tr>
+</table>
+<div class="footnote" style="font-style: italic;">Values shown are for all completed run periods - including any simulations run during sizing periods</div>
+<br><br>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_mod.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_mod.htm
@@ -96,7 +96,114 @@
     <td align="right">21-DEC-07:15</td>
   </tr>
 </table>
-<div class="footnote" style="font-style: italic;">Values shown are for all completed run periods - including any simulations run during sizing periods</div>
+<br><br>
+<b>Monthly Precipitation Summary</b><br><br>
+<!-- FullName:Climatic Data Summary_Entire Facility_Monthly Precipitation Summary-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Monthly Total Precipitation from .epw [mm]</td>
+    <td align="right">Monthly Total Hours of Rain from .epw</td>
+    <td align="right">Monthly Total Precipitation in Site:Precipitation [mm]</td>
+    <td align="right">Monthly Total Roof Irrigation Depth [mm]</td>
+    <td align="right">Monthly Total Rain Collection Volume [m3]</td>
+  </tr>
+  <tr>
+    <td align="right">Feb</td>
+    <td align="right">       0.10</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Jan</td>
+    <td align="right">       0.20</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Mar</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Apr</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">May</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Jun</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Jul</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Aug</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Sep</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Oct</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Nov</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="right">Dec</td>
+    <td align="right">       0.00</td>
+    <td align="right">           0</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+    <td align="right">&nbsp;</td>
+  </tr>
+</table>
 <br><br>
 </body>
 </html>

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_mod.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_row_reorder_mod.htm
@@ -1,0 +1,102 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html lang="">
+<head>
+<title> OutPatientHealthCare RUNPERIOD 3 ** Denver-Aurora-Buckley AFB CO USA TMY3 WMO#=724695
+  2025-05-15
+  09:19:23
+ - EnergyPlus</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 25.2.0-1d1af7dd68, YMD=2025.05.15 09:19</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>OutPatientHealthCare</b></p>
+<p>Environment: <b>RUNPERIOD 3 ** Denver-Aurora-Buckley AFB CO USA TMY3 WMO#=724695</b></p>
+<p>Simulation Timestamp: <b>2025-05-15
+  09:19:23</b></p>
+<hr>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2025-05-15
+    09:19:23</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<a name=EnergyMeters::EntireFacility></a>
+<p>Report:<b> Energy Meters</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2025-05-15
+    09:19:23</b></p>
+<b>Annual and Peak Values - Electricity</b><br><br>
+<!-- FullName:Energy Meters_Entire Facility_Annual and Peak Values - Electricity-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Electricity Annual Value [GJ]</td>
+    <td align="right">Electricity Minimum Value [W]</td>
+    <td align="right">Timestamp of Minimum {TIMESTAMP}</td>
+    <td align="right">Electricity Maximum Value [W]</td>
+    <td align="right">Timestamp of Maximum {TIMESTAMP}</td>
+  </tr>
+  <tr>
+    <td align="right">ElectricityNet:Plant</td>
+    <td align="right">      25.58</td>
+    <td align="right">   79056.27</td>
+    <td align="right">21-DEC-20:15</td>
+    <td align="right">  247648.40</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">Cogeneration:ElectricityNet</td>
+    <td align="right">      25.58</td>
+    <td align="right">   79056.27</td>
+    <td align="right">21-DEC-20:15</td>
+    <td align="right">  247648.40</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+    <tr>
+    <td align="right">Fans:Electricity</td>
+    <td align="right">       2.36</td>
+    <td align="right">    6859.41</td>
+    <td align="right">21-DEC-00:30</td>
+    <td align="right">   32834.85</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">General:Fans:Electricity</td>
+    <td align="right">       2.36</td>
+    <td align="right">    6859.41</td>
+    <td align="right">21-DEC-00:30</td>
+    <td align="right">   32834.85</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">General:Cogeneration:ElectricityNet</td>
+    <td align="right">      25.58</td>
+    <td align="right">   79056.27</td>
+    <td align="right">21-DEC-20:15</td>
+    <td align="right">  247648.40</td>
+    <td align="right">21-JUL-15:00</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity:HVAC</td>
+    <td align="right">      12.30</td>
+    <td align="right">   30407.24</td>
+    <td align="right">21-JUL-04:15</td>
+    <td align="right">  173684.04</td>
+    <td align="right">21-DEC-07:15</td>
+  </tr>
+  <tr>
+    <td align="right">Heating:Electricity</td>
+    <td align="right">       4.43</td>
+    <td align="right">       0.00</td>
+    <td align="right">21-JUL-00:15</td>
+    <td align="right">  140841.61</td>
+    <td align="right">21-DEC-07:15</td>
+  </tr>
+</table>
+<div class="footnote" style="font-style: italic;">Values shown are for all completed run periods - including any simulations run during sizing periods</div>
+<br><br>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_skips_some_tables_base.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_skips_some_tables_base.htm
@@ -1,0 +1,137 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Net Conditioned Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Unconditioned Building Area</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Input Fields</b><br><br>
+<!-- FullName:Object Count Summary_Entire Facility_Input Fields-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Count</td>
+  </tr>
+  <tr>
+    <td align="right">IDF Objects</td>
+    <td align="right">        3836</td>
+  </tr>
+  <tr>
+    <td align="right">Defaulted Fields</td>
+    <td align="right">        3292</td>
+  </tr>
+  <tr>
+    <td align="right">Fields with Defaults</td>
+    <td align="right">       15207</td>
+  </tr>
+  <tr>
+    <td align="right">Autosized Fields</td>
+    <td align="right">         991</td>
+  </tr>
+  <tr>
+    <td align="right">Autosizable Fields</td>
+    <td align="right">        1241</td>
+  </tr>
+  <tr>
+    <td align="right">Autocalculated Fields</td>
+    <td align="right">        1456</td>
+  </tr>
+  <tr>
+    <td align="right">Autocalculatable Fields</td>
+    <td align="right">        2969</td>
+  </tr>
+</table>
+<br><br>
+<hr>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_skips_some_tables_mod.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_skips_some_tables_mod.htm
@@ -1,0 +1,137 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Net Conditioned Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Unconditioned Building Area</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Input Fields</b><br><br>
+<!-- FullName:Object Count Summary_Entire Facility_Input Fields-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Count</td>
+  </tr>
+  <tr>
+    <td align="right">IDF Objects</td>
+    <td align="right">        3836</td>
+  </tr>
+  <tr>
+    <td align="right">Defaulted Fields</td>
+    <td align="right">        3292</td>
+  </tr>
+  <tr>
+    <td align="right">Fields with Defaults</td>
+    <td align="right">       15207</td>
+  </tr>
+  <tr>
+    <td align="right">Autosized Fields</td>
+    <td align="right">         992</td>
+  </tr>
+  <tr>
+    <td align="right">Autosizable Fields</td>
+    <td align="right">        1242</td>
+  </tr>
+  <tr>
+    <td align="right">Autocalculated Fields</td>
+    <td align="right">        1456</td>
+  </tr>
+  <tr>
+    <td align="right">Autocalculatable Fields</td>
+    <td align="right">        2969</td>
+  </tr>
+</table>
+<br><br>
+<hr>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -34,6 +34,26 @@ class TestTableDiff(unittest.TestCase):
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
         self.assertEqual(0, response[8])  # in file 1 but not in file 2
 
+    def test_skips_some_tables(self):
+        response = table_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplustbl_skips_some_tables_base.htm'),
+            os.path.join(self.diff_files_dir, 'eplustbl_skips_some_tables_mod.htm'),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(4, response[1])  # count_of_tables
+        self.assertEqual(0, response[2])  # big diffs
+        self.assertEqual(0, response[3])  # small diffs
+        self.assertEqual(17, response[4])  # equals  # only includes the tables that were compared, not skipped
+        self.assertEqual(0, response[5])  # string diffs
+        self.assertEqual(0, response[6])  # size errors
+        self.assertEqual(0, response[7])  # in file 2 but not in file 1
+        self.assertEqual(0, response[8])  # in file 1 but not in file 2
+
     def test_invalid_file_1(self):
         response = table_diff(
             self.thresh_dict,
@@ -292,7 +312,7 @@ class TestTableDiff(unittest.TestCase):
         self.assertEqual(155, response[1])  # count_of_tables
         self.assertEqual(334, response[2])  # big diffs
         self.assertEqual(67, response[3])  # small diffs
-        self.assertEqual(3763, response[4])  # equals
+        self.assertEqual(3756, response[4])  # equals
         self.assertEqual(21, response[5])  # string diffs
         self.assertEqual(0, response[6])  # size errors
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
@@ -313,7 +333,7 @@ class TestTableDiff(unittest.TestCase):
         self.assertEqual(155, response[1])  # count_of_tables
         self.assertEqual(334, response[2])  # big diffs
         self.assertEqual(67, response[3])  # small diffs
-        self.assertEqual(3763, response[4])  # equals
+        self.assertEqual(3756, response[4])  # equals
         self.assertEqual(21, response[5])  # string diffs
         self.assertEqual(0, response[6])  # size errors
         self.assertEqual(0, response[7])  # in file 2 but not in file 1

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -508,10 +508,10 @@ class TestTableDiff(unittest.TestCase):
             os.path.join(self.temp_output_dir, 'summary.htm'),
         )
         self.assertEqual('', response[0])  # diff status
-        self.assertEqual(1, response[1])  # count_of_tables
-        self.assertEqual(0, response[2])  # big diffs
+        self.assertEqual(2, response[1])  # count_of_tables
+        self.assertEqual(2, response[2])  # big diffs  # Only because of the time-based table reordered
         self.assertEqual(0, response[3])  # small diffs
-        self.assertEqual(35, response[4])  # equals
+        self.assertEqual(93, response[4])  # equals
         self.assertEqual(0, response[5])  # string diffs
         self.assertEqual(0, response[6])  # size errors
         self.assertEqual(0, response[7])  # in file 2 but not in file 1

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -496,6 +496,27 @@ class TestTableDiff(unittest.TestCase):
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
         self.assertEqual(0, response[8])  # in file 1 but not in file 2
 
+    def test_reordering_is_ok_sometimes(self):
+        # This table has a table with the rows reordered
+        response = table_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplustbl_row_reorder_base.htm'),
+            os.path.join(self.diff_files_dir, 'eplustbl_row_reorder_mod.htm'),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(1, response[1])  # count_of_tables
+        self.assertEqual(0, response[2])  # big diffs
+        self.assertEqual(0, response[3])  # small diffs
+        self.assertEqual(35, response[4])  # equals
+        self.assertEqual(0, response[5])  # string diffs
+        self.assertEqual(0, response[6])  # size errors
+        self.assertEqual(0, response[7])  # in file 2 but not in file 1
+        self.assertEqual(0, response[8])  # in file 1 but not in file 2
+
     # it seems like this is something that table_diff just cannot handle.  The duplicate empty column heading is causing
     # major problems.  I'm going to skip this test for now, but leave the two table diff resource files in place
     # so that we could try to investigate later if we ever wanted.


### PR DESCRIPTION
The main objectives here were to:
- allow skipping some of the unhelpful tables, such as the number of autosizable input fields, and
- support row reordering without throwing diffs on most tables

I did a bit of cleanup while in there, and I'll provide a walkthrough of all changes.  I added unit test support to cover the new use cases, and updated existing unit tests to cover the behavior where needed.