### PR TITLE
Throw big table diffs for missing tables or size diffs

### DIFF
--- a/energyplus_regressions/__init__.py
+++ b/energyplus_regressions/__init__.py
@@ -1,2 +1,2 @@
 NAME = 'energyplus_regressions'
-VERSION = '2.1.4'
+VERSION = '2.1.5'

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -467,6 +467,8 @@ def table_diff(
         if uheading1 not in uhset_match:
             table_not_in_2 = 1
             count_of_not_in_2 += table_not_in_2
+            table_big_diff = 1
+            count_of_big_diff += table_big_diff
             make_err_table_row(err_soup, tabletag, uheading1, count_of_tables, abs_diff_file, rel_diff_file,
                                table_small_diff, table_big_diff, table_equal, table_string_diff, table_size_error,
                                table_not_in_1, table_not_in_2)
@@ -479,6 +481,8 @@ def table_diff(
         if len(table1('tr')) != len(table2('tr')) or len(table1('td')) != len(table2('td')):
             table_size_error = 1
             count_of_size_error += table_size_error
+            table_big_diff = 1
+            count_of_big_diff += table_big_diff
             make_err_table_row(err_soup, tabletag, uheading1, count_of_tables, abs_diff_file, rel_diff_file,
                                table_small_diff, table_big_diff, table_equal, table_string_diff, table_size_error,
                                table_not_in_1, table_not_in_2)

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_empty_table_base.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_empty_table_base.htm
@@ -1,0 +1,100 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Net Conditioned Building Area</td>
+    <td align="right">      232.26</td>
+  </tr>
+  <tr>
+    <td align="right">Unconditioned Building Area</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_empty_table_mod.htm
+++ b/energyplus_regressions/tests/diffs/tbl_resources/eplustbl_empty_table_mod.htm
@@ -1,0 +1,92 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN""http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title> Bldg DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** 
+  2018-11-20
+  17:26:37
+ - EnergyPlus</title>
+</head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<body>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=top></a>
+<p>Program Version:<b>EnergyPlus, Version 9.0.1-a7c9cc14ce, YMD=2018.11.20 17:26</b></p>
+<p>Tabular Output Report in Format: <b>HTML</b></p>
+<p>Building: <b>Bldg</b></p>
+<p>Environment: <b>DENVER CENTENNIAL ANN CLG 1% CONDNS DB=>MWB ** </b></p>
+<p>Simulation Timestamp: <b>2018-11-20
+  17:26:37</b></p>
+<hr>
+<p><a href="#toc" style="float: right">Table of Contents</a></p>
+<a name=AnnualBuildingUtilityPerformanceSummary::EntireFacility></a>
+<p>Report:<b> Annual Building Utility Performance Summary</b></p>
+<p>For:<b> Entire Facility</b></p>
+<p>Timestamp: <b>2018-11-20
+    17:26:37</b></p>
+<b>Values gathered over         0.00 hours</b><br><br>
+<b>WARNING: THE REPORT DOES NOT REPRESENT A FULL ANNUAL SIMULATION.</b><br><br>
+<b></b><br><br>
+<b>Site and Source Energy</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site and Source Energy-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Total Energy [GJ]</td>
+    <td align="right">Energy Per Total Building Area [MJ/m2]</td>
+    <td align="right">Energy Per Conditioned Building Area [MJ/m2]</td>
+  </tr>
+  <tr>
+    <td align="right">Total Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Site Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Total Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+  <tr>
+    <td align="right">Net Source Energy</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+    <td align="right">        0.00</td>
+  </tr>
+</table>
+<br><br>
+<b>Site to Source Energy Conversion Factors</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Site to Source Energy Conversion Factors-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Site=>Source Conversion Factor</td>
+  </tr>
+  <tr>
+    <td align="right">Electricity</td>
+    <td align="right">       3.167</td>
+  </tr>
+  <tr>
+    <td align="right">Natural Gas</td>
+    <td align="right">       1.084</td>
+  </tr>
+</table>
+<br><br>
+<b>Building Area</b><br><br>
+<!-- FullName:Annual Building Utility Performance Summary_Entire Facility_Building Area-->
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><td></td>
+    <td align="right">Area [m2]</td>
+  </tr>
+  <tr>
+    <td align="right">None</td>
+    <td align="right"></td>
+  </tr>
+</table>
+<br><br>
+</body>
+</html>

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -54,6 +54,26 @@ class TestTableDiff(unittest.TestCase):
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
         self.assertEqual(0, response[8])  # in file 1 but not in file 2
 
+    def test_mod_file_has_empty_table(self):
+        response = table_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplustbl_empty_table_base.htm'),
+            os.path.join(self.diff_files_dir, 'eplustbl_empty_table_mod.htm'),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(3, response[1])  # count_of_tables
+        self.assertEqual(1, response[2])  # big diffs
+        self.assertEqual(0, response[3])  # small diffs
+        self.assertEqual(14, response[4])  # equals
+        self.assertEqual(0, response[5])  # string diffs
+        self.assertEqual(1, response[6])  # size errors
+        self.assertEqual(0, response[7])  # in file 2 but not in file 1
+        self.assertEqual(0, response[8])  # in file 1 but not in file 2
+
     def test_invalid_file_1(self):
         response = table_diff(
             self.thresh_dict,
@@ -106,7 +126,7 @@ class TestTableDiff(unittest.TestCase):
         )
         self.assertEqual('', response[0])  # diff status
         self.assertEqual(3, response[1])  # count_of_tables
-        self.assertEqual(0, response[2])  # big diffs
+        self.assertEqual(1, response[2])  # big diffs
         self.assertEqual(0, response[3])  # small diffs
         self.assertEqual(14, response[4])  # equals
         self.assertEqual(0, response[5])  # string diffs
@@ -146,7 +166,7 @@ class TestTableDiff(unittest.TestCase):
         )
         self.assertEqual('', response[0])  # diff status
         self.assertEqual(3, response[1])  # count_of_tables
-        self.assertEqual(0, response[2])  # big diffs
+        self.assertEqual(1, response[2])  # big diffs
         self.assertEqual(0, response[3])  # small diffs
         self.assertEqual(14, response[4])  # equals
         self.assertEqual(0, response[5])  # string diffs


### PR DESCRIPTION
We do capture table diffs resulting from a table that goes missing, or a table that has a size error.  But as of now, these don't also throw a BIG DIFF, so they are easier to look past.  I simply added that it should throw a big diff in addition to the missing/size diffs that are also captured.  

New test files and unit test added, other tests updated to now have the big diff in place.