### PR TITLE
Skip Time Diffs on ExpandObjects stdout

### DIFF
--- a/energyplus_regressions/runtests.py
+++ b/energyplus_regressions/runtests.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import json
 from pathlib import Path
 from platform import system
+import re
 import shutil
 import sys
 
@@ -528,13 +529,6 @@ class SuiteRunner:
 
     @staticmethod
     def diff_text_files(file_a: Path, file_b: Path, diff_file: Path):
-        # read the contents of the two files into a list, could read it into text first
-        with file_a.open(encoding='utf-8') as f_txt_1:
-            txt1 = f_txt_1.readlines()
-        with file_b.open(encoding='utf-8') as f_txt_2:
-            txt2 = f_txt_2.readlines()
-        # remove any lines that have some specific listed strings in them
-        txt1_cleaned = []
         skip_strings = [
             "Program Version,EnergyPlus",
             "Version,",
@@ -550,24 +544,33 @@ class SuiteRunner:
             "ReadVars Run Time",
             "EnergyPlus Program Version",
             "PythonPlugin: Class",
-            "ExpandObjects Finished. Time:",
             "EnergyPlus, Version",
             "EnergyPlus Run Time=",
             "ParametricPreprocessor Finished. Time:",
-            "ExpandObjects Finished with Error(s). Time:",
             "Elapsed time: ",
         ]
-        for line in txt1:
-            if any([x in line for x in skip_strings]):
-                txt1_cleaned.append('-line skipped-')
-            else:
-                txt1_cleaned.append(line)
-        txt2_cleaned = []
-        for line in txt2:
-            if any([x in line for x in skip_strings]):
-                txt2_cleaned.append('-line skipped-')
-            else:
-                txt2_cleaned.append(line)
+        expand_objects_time = re.compile(
+            r"(\bTime\s*[:=]\s*)"
+            r"(\d+(?:\.\d+)?(?:\s*(?:hr|min|sec|ms|s))?"
+            r"(?:\s+\d+(?:\.\d+)?\s*(?:hr|min|sec|ms|s))*)",
+            re.IGNORECASE
+        )
+
+        def normalize_line(line):
+            if 'expandobjects' in line.lower():
+                return expand_objects_time.sub(r'\1<time ignored>', line)
+            if any(x in line for x in skip_strings):
+                return '-line skipped-'
+            return line
+
+        # read the contents of the two files into a list, could read it into text first
+        with file_a.open(encoding='utf-8') as f_txt_1:
+            txt1 = f_txt_1.readlines()
+        with file_b.open(encoding='utf-8') as f_txt_2:
+            txt2 = f_txt_2.readlines()
+        # remove any lines that have some specific listed strings or patterns in them
+        txt1_cleaned = [normalize_line(line) for line in txt1]
+        txt2_cleaned = [normalize_line(line) for line in txt2]
         if txt1_cleaned == txt2_cleaned:
             return TextDifferences.EQUAL
 

--- a/energyplus_regressions/tests/test_runtests.py
+++ b/energyplus_regressions/tests/test_runtests.py
@@ -2264,6 +2264,26 @@ class TestTestSuiteRunner(unittest.TestCase):
         diff_file = self.temp_base_build_dir / 'err.diff'
         self.assertEqual(TextDifferences.EQUAL, SuiteRunner.diff_text_files(base_err, mod_err, diff_file))
 
+    def test_stdout_diff_equal_with_expandobjects_time_variants(self):
+        base_stdout = self.temp_mod_source_dir / 'base.stdout'
+        mod_stdout = self.temp_mod_source_dir / 'mod.stdout'
+        with open(base_stdout, 'w') as f:
+            f.write('ExpandObjects Finished. Time: 00hr 00min 0.01sec\nOther output\n')
+        with open(mod_stdout, 'w') as f:
+            f.write('ExpandObjects Finished. Time: 00hr 00min 2.34sec\nOther output\n')
+        diff_file = self.temp_base_build_dir / 'stdout.diff'
+        self.assertEqual(TextDifferences.EQUAL, SuiteRunner.diff_text_files(base_stdout, mod_stdout, diff_file))
+
+    def test_stdout_diff_flags_expandobjects_non_time_differences(self):
+        base_stdout = self.temp_mod_source_dir / 'base.stdout'
+        mod_stdout = self.temp_mod_source_dir / 'mod.stdout'
+        with open(base_stdout, 'w') as f:
+            f.write('ExpandObjects Finished. Time: 0.01\nOther output\n')
+        with open(mod_stdout, 'w') as f:
+            f.write('ExpandObjects Finished with Error(s). Time: 2.34\nOther output\n')
+        diff_file = self.temp_base_build_dir / 'stdout.diff'
+        self.assertEqual(TextDifferences.DIFFS, SuiteRunner.diff_text_files(base_stdout, mod_stdout, diff_file))
+
     def test_perf_log_equal_with_ignored_differences(self):
         base_perf_log = self.resources / 'eplusout_perflog_base.csv'
         mod_perf_log = self.resources / 'eplusout_perflog_same_except_times.csv'


### PR DESCRIPTION
ExpandObjects now fatals properly (https://github.com/NatLabRockies/EnergyPlus/pull/11646) and is causing diffs in stdout. This PR ignores diffs when the runtime is different for ExpandObjects but will still throw on other changes.