### PR TITLE
Report Table Reordering

### DIFF
--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -87,6 +87,9 @@ td.table_size_error {
 td.stringdiff {
     background-color: #F6D8AE;
 }
+td.reordered {
+    background-color: #DDEEFF;
+}
 .big {
     background-color: #FF969D;
 }
@@ -97,6 +100,9 @@ td.stringdiff {
 
 .stringdiff {
     background-color: #F6D8AE;
+}
+.reordered {
+    background-color: #DDEEFF;
 }
 
 """
@@ -170,6 +176,10 @@ def row_cells_for_match(trow):
     return [normalize_row_match_value(tcol.get_text(' ', strip=True)) for tcol in trow('td')]
 
 
+def row_order_changed(original_rows, reordered_rows):
+    return any(original_row is not reordered_row for original_row, reordered_row in zip(original_rows, reordered_rows))
+
+
 def reorder_rows_to_match(base_keys, search_keys, search_rows):
     rows_by_key = defaultdict(deque)
     for key, row in zip(search_keys, search_rows):
@@ -184,7 +194,7 @@ def reorder_rows_to_match(base_keys, search_keys, search_rows):
     return reordered_rows
 
 
-def match_search_rows_to_base_rows(base_rows, search_rows):
+def match_search_rows_to_base_rows_with_status(base_rows, search_rows):
     """
     Reorder search_rows to match base_rows when row order is not semantically meaningful.
 
@@ -195,16 +205,17 @@ def match_search_rows_to_base_rows(base_rows, search_rows):
     may legitimately differ.
     """
     if not base_rows or not search_rows:
-        return search_rows
+        return search_rows, False
 
     base_keys = [row_cells_for_match(trow) for trow in base_rows]
     search_keys = [row_cells_for_match(trow) for trow in search_rows]
 
     if base_keys == search_keys:
-        return search_rows
+        return search_rows, False
 
     if Counter(map(tuple, base_keys)) == Counter(map(tuple, search_keys)):
-        return reorder_rows_to_match(base_keys, search_keys, search_rows)
+        reordered_rows = reorder_rows_to_match(base_keys, search_keys, search_rows)
+        return reordered_rows, row_order_changed(search_rows, reordered_rows)
 
     max_prefix_len = min(
         min((len(key) for key in base_keys), default=0),
@@ -220,9 +231,15 @@ def match_search_rows_to_base_rows(base_rows, search_rows):
         if Counter(base_prefixes) != Counter(search_prefixes):
             continue
 
-        return reorder_rows_to_match(base_prefixes, search_prefixes, search_rows)
+        reordered_rows = reorder_rows_to_match(base_prefixes, search_prefixes, search_rows)
+        return reordered_rows, row_order_changed(search_rows, reordered_rows)
 
-    return search_rows
+    return search_rows, False
+
+
+def match_search_rows_to_base_rows(base_rows, search_rows):
+    reordered_rows, _ = match_search_rows_to_base_rows_with_status(base_rows, search_rows)
+    return reordered_rows
 
 
 def hdict2soup(soup, heading, num, hdict, tdict, horder):
@@ -344,9 +361,10 @@ def table2hdict_horder(table, table_a=None):
     # But we can handle it specially if we passed in table_a and the rows are just reordered.
     # Prefer whole-row matching first, but if a row has actual value diffs we can still align it
     # by the shortest unique leading-column key that exists in both tables.
+    reordered = False
     if table_a:
         trows_a = table_a('tr')
-        search_rows = match_search_rows_to_base_rows(trows_a[1:], search_rows)
+        search_rows, reordered = match_search_rows_to_base_rows_with_status(trows_a[1:], search_rows)
 
     # whether it was reordered or just using the literal order, build out the hdict instance to pass back
     for trow in search_rows:
@@ -363,11 +381,11 @@ def table2hdict_horder(table, table_a=None):
 
             hdict[hcontents].append(contents)
 
-    return hdict, horder
+    return hdict, horder, reordered
 
 
 def make_err_table_row(err_soup, tabletag, uheading, count_of_tables, abs_diff_file, rel_diff_file,
-                       small_diff, big_diff, equal, string_diff, size_error, not_in_1, not_in_2):
+                       small_diff, big_diff, equal, string_diff, size_error, not_in_1, not_in_2, reordered):
     # Create entry in error table
     trtag = Tag(err_soup, name='tr')
     tabletag.append(trtag)
@@ -418,6 +436,10 @@ def make_err_table_row(err_soup, tabletag, uheading, count_of_tables, abs_diff_f
     tdtag_table_size_error.append(
         'size mismatch' if size_error > 0 else 'not in 1' if not_in_1 > 0 else 'not in 2' if not_in_2 > 0 else '')
 
+    tdtag_reordered = Tag(err_soup, name='td', attrs={'class': 'reordered'} if reordered else None)
+    trtag.append(tdtag_reordered)
+    tdtag_reordered.append('yes' if reordered else '')
+
 
 def table_diff(
         thresh_dict: ThreshDict, input_file_1: str, input_file_2: str, abs_diff_file: str,
@@ -428,7 +450,7 @@ def table_diff(
     (
         <message>, <#tables>, <#big_diff>,
         <#small_diff>, <#equals>, <#string_diff>,
-        <#size_diff>, <#not_in_file1>, <#not_in_file2>
+        <#size_diff>, <#not_in_file1>, <#not_in_file2>, <#reordered_tables>
     )
     """
     file_1 = Path(input_file_1)
@@ -438,9 +460,9 @@ def table_diff(
 
     # Test for existence of input files
     if not file_1.exists():
-        return 'unable to open file <%s>' % input_file_1, 0, 0, 0, 0, 0, 0, 0, 0
+        return 'unable to open file <%s>' % input_file_1, 0, 0, 0, 0, 0, 0, 0, 0, 0
     if not file_2.exists():
-        return 'unable to open file <%s>' % input_file_2, 0, 0, 0, 0, 0, 0, 0, 0
+        return 'unable to open file <%s>' % input_file_2, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     with open(file_1, 'rb') as f_1:
         txt1 = f_1.read().decode('utf-8', errors='ignore')
@@ -467,7 +489,10 @@ def table_diff(
     # Make error table headings
     trtag = Tag(err_soup, name='tr')
     tabletag.append(trtag)
-    for title in ['Table', 'Abs file', 'Rel file', 'Big diffs', 'Small diffs', 'Equals', 'String diffs', 'Size diffs']:
+    for title in [
+        'Table', 'Abs file', 'Rel file', 'Big diffs', 'Small diffs', 'Equals', 'String diffs', 'Size diffs',
+        'Reordered'
+    ]:
         thtag = Tag(err_soup, name='th')
         trtag.append(thtag)
         thtag.append(title)
@@ -487,13 +512,16 @@ def table_diff(
         uheadings2.append(get_table_unique_heading(table))
 
     if any([x is None for x in uheadings1]):
-        return 'malformed comment/table structure in <%s>' % input_file_1, 0, 0, 0, 0, 0, 0, 0, 0
+        return 'malformed comment/table structure in <%s>' % input_file_1, 0, 0, 0, 0, 0, 0, 0, 0, 0
     if any([x is None for x in uheadings2]):
-        return 'malformed comment/table structure in <%s>' % input_file_2, 0, 0, 0, 0, 0, 0, 0, 0
+        return 'malformed comment/table structure in <%s>' % input_file_2, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     uhset1 = set(uheadings1)
     uhset2 = set(uheadings2)
     uhset_match = set.intersection(uhset1, uhset2)
+    uheading_positions2 = defaultdict(deque)
+    for i2, uheading2 in enumerate(uheadings2):
+        uheading_positions2[uheading2].append(i2)
 
     count_of_tables = 0
     count_of_tables_diff = 0
@@ -505,6 +533,7 @@ def table_diff(
     count_of_size_error = 0
     count_of_not_in_1 = 0
     count_of_not_in_2 = 0
+    count_of_reordered_tables = 0
 
     for i1 in range(0, len(list(uheadings1))):
 
@@ -517,6 +546,7 @@ def table_diff(
         table_size_error = 0
         table_not_in_1 = 0
         table_not_in_2 = 0
+        table_reordered = False
 
         uheading1 = uheadings1[i1]
 
@@ -536,11 +566,14 @@ def table_diff(
             count_of_big_diff += table_big_diff
             make_err_table_row(err_soup, tabletag, uheading1, count_of_tables, abs_diff_file, rel_diff_file,
                                table_small_diff, table_big_diff, table_equal, table_string_diff, table_size_error,
-                               table_not_in_1, table_not_in_2)
+                               table_not_in_1, table_not_in_2, table_reordered)
             continue
 
         table1 = tables1[i1]
-        table2 = tables2[uheadings2.index(uheading1)]
+        table2_index = uheadings2.index(uheading1)
+        table2_order_index = uheading_positions2[uheading1].popleft()
+        table2 = tables2[table2_index]
+        table_reordered = table2_order_index != i1
 
         # Table size error
         if len(table1('tr')) != len(table2('tr')) or len(table1('td')) != len(table2('td')):
@@ -548,25 +581,19 @@ def table_diff(
             count_of_size_error += table_size_error
             table_big_diff = 1
             count_of_big_diff += table_big_diff
+            if table_reordered:
+                count_of_reordered_tables += 1
             make_err_table_row(err_soup, tabletag, uheading1, count_of_tables, abs_diff_file, rel_diff_file,
                                table_small_diff, table_big_diff, table_equal, table_string_diff, table_size_error,
-                               table_not_in_1, table_not_in_2)
+                               table_not_in_1, table_not_in_2, table_reordered)
             continue
 
-        # create a list of order-dependent table uheading keys, tables that include these keys in the name
-        # these will use strict row order enforcement
-        row_order_dependent_table_keys = ['Monthly', 'Topology']
-
         # always process the first table into a base hdict
-        hdict1, horder1 = table2hdict_horder(table1)
-
-        # if we are in a row order dependent table, don't pass table1 as a baseline, just use the literal in-place order
-        if any(k in uheading1 for k in row_order_dependent_table_keys):
-            hdict2, horder2 = table2hdict_horder(table2)
-        # but for all other tables, we can use the first table as a baseline to carefully match up the rows
-        else:
-            hdict2, horder2 = table2hdict_horder(table2, table1)
-        compare_row_label_fields = not any(k in uheading1 for k in row_order_dependent_table_keys)
+        hdict1, horder1, _ = table2hdict_horder(table1)
+        hdict2, horder2, rows_reordered = table2hdict_horder(table2, table1)
+        table_reordered = table_reordered or rows_reordered
+        if table_reordered:
+            count_of_reordered_tables += 1
 
         # honestly, if the column headings have changed, this should be an indicator to all reviewers that this needs
         # up close investigation.  As such, we are going to trigger the following things:
@@ -590,7 +617,7 @@ def table_diff(
 
         for h in horder1:
             if h == 'DummyPlaceholder':
-                if h not in horder2 or not compare_row_label_fields:
+                if h not in horder2:
                     diff_dict[h] = hdict1[h]
                 else:
                     diff_dict[h] = []
@@ -638,7 +665,7 @@ def table_diff(
 
         make_err_table_row(err_soup, tabletag, uheading1, count_of_tables, abs_diff_file, rel_diff_file,
                            table_small_diff, table_big_diff, table_equal, table_string_diff, table_size_error,
-                           table_not_in_1, table_not_in_2)
+                           table_not_in_1, table_not_in_2, table_reordered)
 
         # If there were no differences, we are done
         if (table_small_diff == 0) and (table_big_diff == 0) and (table_string_diff == 0):
@@ -668,7 +695,7 @@ def table_diff(
             count_of_tables += 1
             count_of_not_in_1 += 1
             make_err_table_row(err_soup, tabletag, uheading2, count_of_tables, abs_diff_file, rel_diff_file,
-                               0, 0, 0, 0, 0, 1, 0)
+                               0, 0, 0, 0, 0, 1, 0, False)
 
     # Write error file
     err_txt = err_soup.prettify()
@@ -690,16 +717,16 @@ def table_diff(
             with open(summary_file, 'w') as summarize:
                 summarize.write(
                     "Case,TableCount,BigDiffCount,SmallDiffCount,EqualCount,"
-                    "StringDiffCount,SizeErrorCount,NotIn1Count,NotIn2Count\n"
+                    "StringDiffCount,SizeErrorCount,NotIn1Count,NotIn2Count,ReorderedTableCount\n"
                 )
         with open(summary_file, 'a') as summarize:
-            summarize.write("%s,%s,%s,%s,%s,%s,%s,%s,%s\n" % (
+            summarize.write("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n" % (
                 case_name, count_of_tables, count_of_big_diff, count_of_small_diff, count_of_equal,
                 count_of_string_diff,
-                count_of_size_error, count_of_not_in_1, count_of_not_in_2))
+                count_of_size_error, count_of_not_in_1, count_of_not_in_2, count_of_reordered_tables))
 
     return ('', count_of_tables, count_of_big_diff, count_of_small_diff, count_of_equal, count_of_string_diff,
-            count_of_size_error, count_of_not_in_1, count_of_not_in_2)
+            count_of_size_error, count_of_not_in_1, count_of_not_in_2, count_of_reordered_tables)
 
 
 def main(argv=None) -> int:  # pragma: no cover

--- a/energyplus_regressions/diffs/table_diff.py
+++ b/energyplus_regressions/diffs/table_diff.py
@@ -674,7 +674,7 @@ def table_diff(
         # Add difference tables to absolute and relative difference soups
         abs_diff_dict = {}
         for h in horder1:
-            if h not in horder2:
+            if h not in horder2 and h != 'DummyPlaceholder':
                 continue
             abs_diff_dict[h] = diff_dict[h] if (h == 'DummyPlaceholder' or h == 'Subcategory') else [
                 (x_y_z[0], x_y_z[2]) for x_y_z in diff_dict[h]]
@@ -682,7 +682,7 @@ def table_diff(
 
         rel_diff_dict = {}
         for h in horder1:
-            if h not in horder2:
+            if h not in horder2 and h != 'DummyPlaceholder':
                 continue
             rel_diff_dict[h] = diff_dict[h] if (h == 'DummyPlaceholder' or h == 'Subcategory') else [
                 (x_y_z[1], x_y_z[2]) for x_y_z in diff_dict[h]]

--- a/energyplus_regressions/structures.py
+++ b/energyplus_regressions/structures.py
@@ -151,6 +151,7 @@ class TableDifferences:
         self.size_err_count = args_from_table_diff[6]
         self.not_in_1_count = args_from_table_diff[7]
         self.not_in_2_count = args_from_table_diff[8]
+        self.reordered_table_count = args_from_table_diff[9] if len(args_from_table_diff) > 9 else 0
 
     def to_dict(self):
         response = dict()
@@ -163,6 +164,7 @@ class TableDifferences:
         response['size_err_count'] = self.size_err_count
         response['not_in_1_count'] = self.not_in_1_count
         response['not_in_2_count'] = self.not_in_2_count
+        response['reordered_table_count'] = self.reordered_table_count
         return response
 
 

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -688,6 +688,84 @@ class TestTableDiff(unittest.TestCase):
         self.assertIn('Reordered', err_summary)
         self.assertIn('yes', err_summary)
 
+    def test_reordered_table_with_size_error_counts_as_reordered(self):
+        base_file = Path(self.temp_output_dir) / 'reordered_size_error_base.htm'
+        mod_file = Path(self.temp_output_dir) / 'reordered_size_error_mod.htm'
+        base_file.write_text("""
+            <html><body>
+            <!-- FullName:Report_A -->
+            <table><tr><td></td><td>Value</td></tr><tr><td>A</td><td>1</td></tr></table>
+            <!-- FullName:Report_B -->
+            <table><tr><td></td><td>Value</td></tr><tr><td>B</td><td>2</td></tr></table>
+            </body></html>
+        """)
+        mod_file.write_text("""
+            <html><body>
+            <!-- FullName:Report_B -->
+            <table><tr><td></td><td>Value</td></tr><tr><td>B</td><td>2</td></tr></table>
+            <!-- FullName:Report_A -->
+            <table>
+              <tr><td></td><td>Value</td></tr>
+              <tr><td>A</td><td>1</td></tr>
+              <tr><td>A2</td><td>3</td></tr>
+            </table>
+            </body></html>
+        """)
+
+        response = table_diff(
+            self.thresh_dict,
+            str(base_file),
+            str(mod_file),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(2, response[1])  # count_of_tables
+        self.assertEqual(1, response[2])  # big diffs
+        self.assertEqual(1, response[6])  # size errors
+        self.assertEqual(2, response[9])  # reordered tables
+
+    def test_blank_row_label_heading_missing_from_modified_table(self):
+        base_file = Path(self.temp_output_dir) / 'blank_row_heading_base.htm'
+        mod_file = Path(self.temp_output_dir) / 'blank_row_heading_mod.htm'
+        base_file.write_text("""
+            <html><body>
+            <!-- FullName:Report_A -->
+            <table>
+              <tr><td></td><td>Value</td></tr>
+              <tr><td>A</td><td>1</td></tr>
+            </table>
+            </body></html>
+        """)
+        mod_file.write_text("""
+            <html><body>
+            <!-- FullName:Report_A -->
+            <table>
+              <tr><td>Row Label</td><td>Value</td></tr>
+              <tr><td>A</td><td>1</td></tr>
+            </table>
+            </body></html>
+        """)
+
+        response = table_diff(
+            self.thresh_dict,
+            str(base_file),
+            str(mod_file),
+            os.path.join(self.temp_output_dir, 'abs_diff.htm'),
+            os.path.join(self.temp_output_dir, 'rel_diff.htm'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.htm'),
+        )
+
+        self.assertEqual('', response[0])  # diff status
+        self.assertEqual(1, response[1])  # count_of_tables
+        self.assertEqual(1, response[2])  # big diffs
+        self.assertEqual(1, response[5])  # string diffs
+        self.assertEqual(1, response[6])  # size errors
+
     def test_reordering_with_case_only_key_column_changes_and_real_value_diff(self):
         # Coil sizing tables can reorder rows while also changing the presentation case of an
         # identifier column. We still want to align rows by their stable leading key while

--- a/energyplus_regressions/tests/diffs/test_table_diff.py
+++ b/energyplus_regressions/tests/diffs/test_table_diff.py
@@ -671,13 +671,22 @@ class TestTableDiff(unittest.TestCase):
         )
         self.assertEqual('', response[0])  # diff status
         self.assertEqual(2, response[1])  # count_of_tables
-        self.assertEqual(2, response[2])  # big diffs  # Only because of the time-based table reordered
+        self.assertEqual(0, response[2])  # big diffs
         self.assertEqual(0, response[3])  # small diffs
-        self.assertEqual(93, response[4])  # equals
+        self.assertEqual(95, response[4])  # equals
         self.assertEqual(0, response[5])  # string diffs
         self.assertEqual(0, response[6])  # size errors
         self.assertEqual(0, response[7])  # in file 2 but not in file 1
         self.assertEqual(0, response[8])  # in file 1 but not in file 2
+        self.assertEqual(2, response[9])  # reordered tables
+
+        summary = Path(os.path.join(self.temp_output_dir, 'summary.htm')).read_text()
+        self.assertIn('ReorderedTableCount', summary)
+        self.assertIn(',2\n', summary)
+
+        err_summary = Path(os.path.join(self.temp_output_dir, 'math_diff.log')).read_text()
+        self.assertIn('Reordered', err_summary)
+        self.assertIn('yes', err_summary)
 
     def test_reordering_with_case_only_key_column_changes_and_real_value_diff(self):
         # Coil sizing tables can reorder rows while also changing the presentation case of an

--- a/energyplus_regressions/tests/test_structures.py
+++ b/energyplus_regressions/tests/test_structures.py
@@ -85,6 +85,13 @@ class TestTableDifferences(unittest.TestCase):
         self.assertIn('table_count', obj)
         self.assertIn('big_diff_count', obj)
         self.assertIn('small_diff_count', obj)
+        self.assertIn('reordered_table_count', obj)
+
+    def test_instance_to_dict_with_reordered_tables(self):
+        from_table_diff = ['msg', 'tbl_count', 0, 0, 2, 0, 0, 0, 0, 1]
+        t = TableDifferences(from_table_diff)
+        obj = t.to_dict()
+        self.assertEqual(1, obj['reordered_table_count'])
 
 
 class TestEndErrSummary(unittest.TestCase):
@@ -276,3 +283,21 @@ class TestCompletedStructure(unittest.TestCase):
         self.assertEqual(['filename'], obj['diffs']['big_table'])
         self.assertEqual([], obj['diffs']['small_table'])
         self.assertEqual(1, obj['results_by_file'][0]['table_diffs']['string_diff_count'])
+
+    def test_to_json_summary_does_not_report_reordered_only_table_as_diff(self):
+        c = CompletedStructure(
+            Path('/a/source/dir'), Path('/a/build/dir'),
+            Path('/b/source/dir'), Path('/b/build/dir'),
+            Path('/r/dir1'), Path('/r/dir2'),
+            datetime.now()
+        )
+        t = TestEntry('filename', 'weather')
+        t.add_summary_result(EndErrSummary(EndErrSummary.STATUS_SUCCESS, 1, EndErrSummary.STATUS_SUCCESS, 1))
+        t.add_table_differences(TableDifferences(['', 1, 0, 0, 2, 0, 0, 0, 0, 1]))
+        c.add_test_entry(t)
+
+        obj = c.to_json_summary()
+
+        self.assertEqual([], obj['diffs']['big_table'])
+        self.assertEqual([], obj['diffs']['small_table'])
+        self.assertEqual(1, obj['results_by_file'][0]['table_diffs']['reordered_table_count'])


### PR DESCRIPTION
Adds a column to the summary file flagging when the table rows have been reordered. Reordering is not flagged as a diff.