### PR TITLE
Modernize and Speed-up the Regression Test Runner

### DIFF
--- a/energyplus_regressions/diffs/math_diff.py
+++ b/energyplus_regressions/diffs/math_diff.py
@@ -54,6 +54,7 @@ __license__ = "GNU General Public License Version 3"
 # - how the program will respond when the time stamps do not match
 # - documentation of data structure in the program
 
+import filecmp
 import getopt
 import os
 import sys
@@ -218,6 +219,40 @@ def info(line, logfile=None):
     # print >> sys.stderr, line
 
 
+def write_summary_csv(summary_csv, input_file_1, diff_type, num_records):
+    if not summary_csv:
+        return
+    input_file_path_tokens = input_file_1.split(os.sep)
+    if not os.path.isfile(summary_csv):
+        with open(summary_csv, 'w') as f:
+            f.write("CaseName,FileName,Status,#Records\n")
+    with open(summary_csv, 'a') as f:
+        f.write(
+            "%s,%s,%s,%s records compared\n" % (
+                input_file_path_tokens[-2], input_file_path_tokens[-1], diff_type, num_records
+            )
+        )
+
+
+def exact_match_result(input_file_1, input_file_2, err_file, summary_csv):
+    if not filecmp.cmp(input_file_1, input_file_2, shallow=False):
+        return None
+    try:
+        mat = mycsv.getlist(input_file_1)
+    except IndexError:
+        return 'malformed or empty csv file: <%s>' % input_file_1, 0, 0, 0
+    if len(mat) < 2:
+        info('<%s> has no data' % input_file_1, err_file)
+        return '<%s> has no data' % input_file_1, 0, 0, 0
+    if isinstance(mat[0], list) and len(set(mat[0])) != len(mat[0]):
+        for header in mat[0]:
+            if mat[0].count(header) > 1:
+                raise DuplicateHeaderException("There are two columns with the same header name " + str(header))
+    num_records = len(mat) - 1
+    write_summary_csv(summary_csv, input_file_1, 'All Equal', num_records)
+    return 'All Equal', num_records, 0, 0
+
+
 def math_diff(thresh_dict, input_file_1, input_file_2, abs_diff_file, rel_diff_file, err_file, summary_csv):
     # Test for existence of input files
     if not os.path.exists(input_file_1):
@@ -226,6 +261,10 @@ def math_diff(thresh_dict, input_file_1, input_file_2, abs_diff_file, rel_diff_f
     if not os.path.exists(input_file_2):
         info('unable to open file <%s>' % input_file_2, err_file)
         return 'unable to open file <%s>' % input_file_2, 0, 0, 0
+
+    fast_result = exact_match_result(input_file_1, input_file_2, err_file, summary_csv)
+    if fast_result:
+        return fast_result
 
     # read data out of files
     try:
@@ -362,20 +401,9 @@ def math_diff(thresh_dict, input_file_1, input_file_2, abs_diff_file, rel_diff_f
 
     num_records = len(t_dict[t_key])
 
-    input_file_path_tokens = input_file_1.split(os.sep)
-
     # if it's the first pass, create the file with the header;
     # also the null-pointer-ish check allows skipping the summary_csv file if the filename is blank
-    if summary_csv:
-        if not os.path.isfile(summary_csv):
-            with open(summary_csv, 'w') as f:
-                f.write("CaseName,FileName,Status,#Records\n")
-        with open(summary_csv, 'a') as f:
-            f.write(
-                "%s,%s,%s,%s records compared\n" % (
-                    input_file_path_tokens[-2], input_file_path_tokens[-1], diff_type, num_records
-                )
-            )
+    write_summary_csv(summary_csv, input_file_1, diff_type, num_records)
 
     # We are done
     if diff_type == 'All Equal':

--- a/energyplus_regressions/energyplus.py
+++ b/energyplus_regressions/energyplus.py
@@ -1,11 +1,18 @@
-import glob
-from os import chdir, getcwd, rename, environ
+import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 
 from energyplus_regressions.builds.base import BuildTree
 from energyplus_regressions.structures import ForceRunType
+
+
+def link_or_copy(source, destination):
+    try:
+        os.link(source, destination)
+    except OSError:
+        shutil.copy(source, destination)
 
 
 class ExecutionArguments:
@@ -34,33 +41,43 @@ def execute_energyplus(e_args: ExecutionArguments) -> tuple[Path, str, bool, boo
     read_vars = e_args.build_tree.readvars
     parametric = e_args.build_tree.parametric
 
-    # Save the current path so we can go back here
-    start_path = getcwd()
-
+    run_directory = e_args.test_run_directory
     std_out = b""
     std_err = b""
 
-    try:
+    def command_args(executable: Path, *args: str) -> list[str]:
+        if executable.suffix.lower() == '.py':
+            return [sys.executable, str(executable), *args]
+        return [str(executable), *args]
 
-        new_idd_path = e_args.test_run_directory / 'Energy+.idd'
-        shutil.copy(idd_path, new_idd_path)
+    def run_command(executable: Path, *args: str, env=None, check: bool = False):
+        return subprocess.run(
+            command_args(executable, *args),
+            cwd=run_directory,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=check
+        )
+
+    try:
+        new_idd_path = run_directory / 'Energy+.idd'
+        link_or_copy(idd_path, new_idd_path)
 
         # Copy the weather file into the simulation directory
         if e_args.weather_file_name:
-            shutil.copy(e_args.weather_file_name, e_args.test_run_directory / 'in.epw')
-
-        # Switch to the simulation directory
-        chdir(e_args.test_run_directory)
+            link_or_copy(e_args.weather_file_name, run_directory / 'in.epw')
 
         # Run EPMacro as necessary
-        idf_file = e_args.test_run_directory / 'in.idf'
-        expanded_file = e_args.test_run_directory / 'expanded.idf'
-        imf_path = e_args.test_run_directory / 'in.imf'
-        ght_file = e_args.test_run_directory / 'GHTIn.idf'
-        basement_file = e_args.test_run_directory / 'BasementGHTIn.idf'
-        ep_json_file = e_args.test_run_directory / 'in.epJSON'
-        rvi_file = e_args.test_run_directory / 'in.rvi'
-        mvi_file = e_args.test_run_directory / 'in.mvi'
+        idf_file = run_directory / 'in.idf'
+        expanded_file = run_directory / 'expanded.idf'
+        imf_path = run_directory / 'in.imf'
+        ght_file = run_directory / 'GHTIn.idf'
+        basement_file = run_directory / 'BasementGHTIn.idf'
+        ep_json_file = run_directory / 'in.epJSON'
+        rvi_file = run_directory / 'in.rvi'
+        mvi_file = run_directory / 'in.mvi'
 
         if imf_path.exists():
             with imf_path.open('rb') as f:
@@ -72,104 +89,87 @@ def execute_energyplus(e_args: ExecutionArguments) -> tuple[Path, str, bool, boo
                     newlines.append('')
                 else:
                     newlines.append(encoded_line)
-            with open('in.imf', 'w') as f:
+            with imf_path.open('w') as f:
                 for line in newlines:
                     f.write(line)
-            macro_run = subprocess.Popen(
-                str(ep_macro), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            o, e = macro_run.communicate()
-            std_out += o
-            std_err += e
-            rename('out.idf', 'in.idf')
+            macro_run = run_command(ep_macro)
+            std_out += macro_run.stdout
+            std_err += macro_run.stderr
+            (run_directory / 'out.idf').rename(idf_file)
 
         # Run Preprocessor -- after EPMacro?
         if e_args.this_parametric_file:
-            parametric_run = subprocess.Popen(
-                str(parametric) + ' in.idf', shell=True, stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            o, e = parametric_run.communicate()
-            std_out += o
-            std_err += e
-            candidate_files = glob.glob('in-*.idf')
+            parametric_run = run_command(parametric, 'in.idf')
+            std_out += parametric_run.stdout
+            std_err += parametric_run.stderr
+            candidate_files = list(run_directory.glob('in-*.idf'))
             if len(candidate_files) > 0:
                 file_to_run_here = sorted(candidate_files)[0]
                 if idf_file.exists():
                     idf_file.unlink()
-                rename(file_to_run_here, idf_file)
+                file_to_run_here.rename(idf_file)
             else:
                 return e_args.build_tree.build_dir, e_args.entry_name, False, False, "Issue with Parametric"
 
         # Run ExpandObjects and process as necessary, but not for epJSON files!
         if idf_file.exists():
-            expand_objects_run = subprocess.Popen(
-                str(expand_objects), shell=True, stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            o, e = expand_objects_run.communicate()
-            std_out += o
-            std_err += e
+            expand_objects_run = run_command(expand_objects)
+            std_out += expand_objects_run.stdout
+            std_err += expand_objects_run.stderr
             if expanded_file.exists():
                 if idf_file.exists():
                     idf_file.unlink()
-                rename(expanded_file, idf_file)
+                expanded_file.rename(idf_file)
 
                 if basement_file.exists():
-                    shutil.copy(basement_idd, e_args.test_run_directory)
-                    basement_environment = environ.copy()
+                    shutil.copy(basement_idd, run_directory)
+                    basement_environment = os.environ.copy()
                     basement_environment['CI_BASEMENT_NUMYEARS'] = '2'
-                    basement_run = subprocess.Popen(
-                        str(basement), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE, env=basement_environment
-                    )
-                    o, e = basement_run.communicate()
-                    std_out += o
-                    std_err += e
-                    with open('EPObjects.TXT') as f:
+                    basement_run = run_command(basement, env=basement_environment)
+                    std_out += basement_run.stdout
+                    std_err += basement_run.stderr
+                    with (run_directory / 'EPObjects.TXT').open() as f:
                         append_text = f.read()
-                    with open('in.idf', 'a') as f:
+                    with idf_file.open('a') as f:
                         f.write("\n%s\n" % append_text)
-                    (e_args.test_run_directory / 'RunINPUT.TXT').unlink()
-                    (e_args.test_run_directory / 'RunDEBUGOUT.TXT').unlink()
-                    (e_args.test_run_directory / 'EPObjects.TXT').unlink()
-                    (e_args.test_run_directory / 'BasementGHTIn.idf').unlink()
-                    (e_args.test_run_directory / 'MonthlyResults.csv').unlink()
-                    (e_args.test_run_directory / 'BasementGHT.idd').unlink()
+                    (run_directory / 'RunINPUT.TXT').unlink()
+                    (run_directory / 'RunDEBUGOUT.TXT').unlink()
+                    (run_directory / 'EPObjects.TXT').unlink()
+                    (run_directory / 'BasementGHTIn.idf').unlink()
+                    (run_directory / 'MonthlyResults.csv').unlink()
+                    (run_directory / 'BasementGHT.idd').unlink()
 
                 if ght_file.exists():
-                    shutil.copy(slab_idd, e_args.test_run_directory)
-                    slab_run = subprocess.Popen(
-                        str(slab), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-                    )
-                    o, e = slab_run.communicate()
-                    std_out += o
-                    std_err += e
-                    with open('SLABSurfaceTemps.TXT') as f:
+                    shutil.copy(slab_idd, run_directory)
+                    slab_run = run_command(slab)
+                    std_out += slab_run.stdout
+                    std_err += slab_run.stderr
+                    with (run_directory / 'SLABSurfaceTemps.TXT').open() as f:
                         append_text = f.read()
-                    with open('in.idf', 'a') as f:
+                    with idf_file.open('a') as f:
                         f.write("\n%s\n" % append_text)
-                    (e_args.test_run_directory / 'SLABINP.TXT').unlink()
-                    (e_args.test_run_directory / 'GHTIn.idf').unlink()
-                    (e_args.test_run_directory / 'SLABSurfaceTemps.TXT').unlink()
-                    (e_args.test_run_directory / 'SLABSplit Surface Temps.TXT').unlink()
-                    (e_args.test_run_directory / 'SlabGHT.idd').unlink()
+                    (run_directory / 'SLABINP.TXT').unlink()
+                    (run_directory / 'GHTIn.idf').unlink()
+                    (run_directory / 'SLABSurfaceTemps.TXT').unlink()
+                    (run_directory / 'SLABSplit Surface Temps.TXT').unlink()
+                    (run_directory / 'SlabGHT.idd').unlink()
 
         # Set up environment
-        environ["DISPLAYADVANCEDREPORTVARIABLES"] = "YES"
-        environ["DISPLAYALLWARNINGS"] = "YES"
+        energyplus_environment = os.environ.copy()
+        energyplus_environment["DISPLAYADVANCEDREPORTVARIABLES"] = "YES"
+        energyplus_environment["DISPLAYALLWARNINGS"] = "YES"
         if e_args.run_type == ForceRunType.DD:
-            environ["DDONLY"] = "Y"
-            environ["REVERSEDD"] = ""
-            environ["FULLANNUALRUN"] = ""
+            energyplus_environment["DDONLY"] = "Y"
+            energyplus_environment["REVERSEDD"] = ""
+            energyplus_environment["FULLANNUALRUN"] = ""
         elif e_args.run_type == ForceRunType.ANNUAL:
-            environ["DDONLY"] = ""
-            environ["REVERSEDD"] = ""
-            environ["FULLANNUALRUN"] = "Y"
+            energyplus_environment["DDONLY"] = ""
+            energyplus_environment["REVERSEDD"] = ""
+            energyplus_environment["FULLANNUALRUN"] = "Y"
         elif e_args.run_type == ForceRunType.NONE:
-            environ["DDONLY"] = ""
-            environ["REVERSEDD"] = ""
-            environ["FULLANNUALRUN"] = ""
+            energyplus_environment["DDONLY"] = ""
+            energyplus_environment["REVERSEDD"] = ""
+            energyplus_environment["FULLANNUALRUN"] = ""
         else:  # pragma: no cover
             # it feels weird to try to test this path...have to set run_type to something invalid?
             # should we just eliminate this else?
@@ -177,16 +177,16 @@ def execute_energyplus(e_args: ExecutionArguments) -> tuple[Path, str, bool, boo
 
         # use the user-entered minimum reporting frequency
         #  (useful for limiting to daily outputs for annual simulation, etc.)
-        environ["MINREPORTFREQUENCY"] = e_args.min_reporting_freq.upper()
+        energyplus_environment["MINREPORTFREQUENCY"] = e_args.min_reporting_freq.upper()
 
         # Execute EnergyPlus
         try:
-            command_line = str(energyplus)
+            energyplus_args = []
             if ep_json_file.exists():
-                command_line += ' in.epJSON'
-            std_out += subprocess.check_output(
-                command_line, shell=True, stdin=subprocess.DEVNULL, stderr=subprocess.PIPE
-            )
+                energyplus_args.append('in.epJSON')
+            energyplus_run = run_command(energyplus, *energyplus_args, env=energyplus_environment, check=True)
+            std_out += energyplus_run.stdout
+            std_err += energyplus_run.stderr
         except subprocess.CalledProcessError as e:  # pragma: no cover
             ...
             # so I can verify that I hit this during the test_case_b_crash test, but if I just have the return in
@@ -195,45 +195,31 @@ def execute_energyplus(e_args: ExecutionArguments) -> tuple[Path, str, bool, boo
 
         # Execute read-vars
         if rvi_file.exists():
-            csv_run = subprocess.Popen(
-                str(read_vars) + ' in.rvi', shell=True, stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
+            csv_run = run_command(read_vars, 'in.rvi')
         else:
-            csv_run = subprocess.Popen(
-                str(read_vars), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        o, e = csv_run.communicate()
-        std_out += o
-        std_err += e
+            csv_run = run_command(read_vars)
+        std_out += csv_run.stdout
+        std_err += csv_run.stderr
         if mvi_file.exists():
-            mtr_run = subprocess.Popen(
-                str(read_vars) + ' in.mvi', shell=True, stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
+            mtr_run = run_command(read_vars, 'in.mvi')
         else:
             with mvi_file.open('w') as f:
                 f.write("eplusout.mtr\n")
                 f.write("eplusmtr.csv\n")
-            mtr_run = subprocess.Popen(
-                str(read_vars) + ' in.mvi', shell=True, stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-        o, e = mtr_run.communicate()
-        std_out += o
-        std_err += e
+            mtr_run = run_command(read_vars, 'in.mvi')
+        std_out += mtr_run.stdout
+        std_err += mtr_run.stderr
 
         if len(std_out) > 0:
-            with open('eplusout.stdout', 'w') as f:
+            with (run_directory / 'eplusout.stdout').open('w') as f:
                 f.write(std_out.decode('utf-8'))
         if len(std_err) > 0:
-            with open('eplusout.stderr', 'w') as f:
+            with (run_directory / 'eplusout.stderr').open('w') as f:
                 f.write(std_err.decode('utf-8'))
 
         new_idd_path.unlink()
-        chdir(start_path)
         return e_args.build_tree.build_dir, e_args.entry_name, True, False, ""
 
     except Exception as e:
         print("**" + str(e))
-        chdir(start_path)
         return e_args.build_tree.build_dir, e_args.entry_name, False, False, str(e)

--- a/energyplus_regressions/runtests.py
+++ b/energyplus_regressions/runtests.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import argparse
 from datetime import datetime
+import filecmp
 import json
 from pathlib import Path
 from platform import system
@@ -37,6 +38,14 @@ from multiprocessing import Pool
 
 # get the current file path for convenience
 script_dir = Path(__file__).resolve().parent
+_thresh_dict_cache = {}
+
+
+def get_thresh_dict(thresh_dict_file):
+    cache_key = str(Path(thresh_dict_file).resolve())
+    if cache_key not in _thresh_dict_cache:
+        _thresh_dict_cache[cache_key] = td.ThreshDict(thresh_dict_file)
+    return _thresh_dict_cache[cache_key]
 
 
 class TestRunConfiguration:
@@ -138,12 +147,8 @@ class SuiteRunner:
         start_time = datetime.now()
         self.my_starting(len(self.entries))
 
-        # run the energyplus script
-        self.run_build(self.build_tree_a)
-        if self.id_like_to_stop_now:  # pragma: no cover
-            self.my_cancelled()
-            return
-        self.run_build(self.build_tree_b)
+        # run the energyplus simulations
+        self.run_builds([self.build_tree_a, self.build_tree_b])
         if self.id_like_to_stop_now:  # pragma: no cover
             self.my_cancelled()
             return
@@ -260,7 +265,7 @@ class SuiteRunner:
 
         return idf_text
 
-    def run_build(self, build_tree: BuildTree):
+    def prepare_build_runs(self, build_tree: BuildTree):
 
         this_test_dir: str = self.test_output_dir
         local_run_type: str = self.force_run_type
@@ -452,6 +457,18 @@ class SuiteRunner:
                 )
             )
 
+        return energy_plus_runs
+
+    def run_build(self, build_tree: BuildTree):
+        self.execute_energyplus_runs(self.prepare_build_runs(build_tree))
+
+    def run_builds(self, build_trees: list[BuildTree]):
+        energy_plus_runs = []
+        for build_tree in build_trees:
+            energy_plus_runs.extend(self.prepare_build_runs(build_tree))
+        self.execute_energyplus_runs(energy_plus_runs)
+
+    def execute_energyplus_runs(self, energy_plus_runs: list[ExecutionArguments]):
         # So...on Windows, pyinstaller freezes the application, and then multiprocessing vomits on this.
         # If you are running this from code, say from a Pip install, it works fine.  It's merely the combination of
         # freezing _plus_ multiprocessing.  Apparently the tool needs to run multiprocessing.freeze_support(), which I
@@ -491,6 +508,8 @@ class SuiteRunner:
     def diff_perf_log(file_a: Path, file_b: Path, diff_file: Path):
         # will do a pretty simple CSV text token comparison, no numeric comparison, and omit some certain patterns
         tokens_to_skip = [1, 2, 27, 28, 30, 31]
+        if filecmp.cmp(file_a, file_b, shallow=False):
+            return TextDifferences.EQUAL
         with file_a.open(encoding='utf-8') as f_txt_1:
             txt1 = f_txt_1.readlines()
         with file_b.open(encoding='utf-8') as f_txt_2:
@@ -563,6 +582,9 @@ class SuiteRunner:
                 return '-line skipped-'
             return line
 
+        if filecmp.cmp(file_a, file_b, shallow=False):
+            return TextDifferences.EQUAL
+
         # read the contents of the two files into a list, could read it into text first
         with file_a.open(encoding='utf-8') as f_txt_1:
             txt1 = f_txt_1.readlines()
@@ -626,13 +648,12 @@ class SuiteRunner:
 
     @staticmethod
     def diff_glhe_files(file_a: Path, file_b: Path, diff_file: Path):
+        if filecmp.cmp(file_a, file_b, shallow=False):
+            return TextDifferences.EQUAL
         with file_a.open(encoding='utf-8') as f_txt_1:
             txt1 = f_txt_1.read()
         with file_b.open(encoding='utf-8') as f_txt_2:
             txt2 = f_txt_2.read()
-        # return early if the files match
-        if txt1 == txt2:
-            return TextDifferences.EQUAL
         # if they don't match as a string, they could still match in terms of values, need to parse into objects
         json_1 = json.loads(txt1)
         json_2 = json.loads(txt2)
@@ -731,13 +752,12 @@ class SuiteRunner:
         num_values_checked = 0
         num_big_diffs = 0
         num_small_diffs = 0
+        if filecmp.cmp(file_a, file_b, shallow=False):
+            return resulting_diff_type, num_values_checked, num_big_diffs, num_small_diffs
         with file_a.open(encoding='utf-8') as f_txt_1:
             txt1 = f_txt_1.read()
         with file_b.open(encoding='utf-8') as f_txt_2:
             txt2 = f_txt_2.read()
-        # return early if the files match
-        if txt1 == txt2:
-            return resulting_diff_type, num_values_checked, num_big_diffs, num_small_diffs
         # if they don't match as a string, they could still match in terms of values, need to parse into objects
         json_1 = json.loads(txt1)
         json_2 = json.loads(txt2)
@@ -901,7 +921,7 @@ class SuiteRunner:
             return this_entry, "Skipping an entry because it has an unknown end status: %s" % this_entry.basename
 
         # Load diffing threshold dictionary
-        thresh_dict = td.ThreshDict(thresh_dict_file)
+        thresh_dict = get_thresh_dict(thresh_dict_file)
 
         # Do Math (CSV) Diffs
         if SuiteRunner.both_files_exist(case_result_dir_1, case_result_dir_2, 'eplusout.csv'):

--- a/energyplus_regressions/tests/diffs/test_math_diff.py
+++ b/energyplus_regressions/tests/diffs/test_math_diff.py
@@ -29,6 +29,48 @@ class TestMathDiff(unittest.TestCase):
         self.assertEqual(0, response[2])  # big diffs
         self.assertEqual(0, response[3])  # small diffs
 
+    def test_identical_totally_empty_files(self):
+        response = math_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplusout_totally_empty.csv'),
+            os.path.join(self.diff_files_dir, 'eplusout_totally_empty.csv'),
+            os.path.join(self.temp_output_dir, 'abs_diff.csv'),
+            os.path.join(self.temp_output_dir, 'rel_diff.csv'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.csv'),
+        )
+        self.assertIn('malformed or empty csv file', response[0])
+        self.assertEqual(0, response[1])
+        self.assertEqual(0, response[2])
+        self.assertEqual(0, response[3])
+
+    def test_identical_empty_data_files(self):
+        response = math_diff(
+            self.thresh_dict,
+            os.path.join(self.diff_files_dir, 'eplusout_empty_data.csv'),
+            os.path.join(self.diff_files_dir, 'eplusout_empty_data.csv'),
+            os.path.join(self.temp_output_dir, 'abs_diff.csv'),
+            os.path.join(self.temp_output_dir, 'rel_diff.csv'),
+            os.path.join(self.temp_output_dir, 'math_diff.log'),
+            os.path.join(self.temp_output_dir, 'summary.csv'),
+        )
+        self.assertIn('has no data', response[0])
+        self.assertEqual(0, response[1])
+        self.assertEqual(0, response[2])
+        self.assertEqual(0, response[3])
+
+    def test_identical_duplicate_header_fails(self):
+        with self.assertRaises(DuplicateHeaderException):
+            math_diff(
+                self.thresh_dict,
+                os.path.join(self.diff_files_dir, 'eplusout_duplicate_header.csv'),
+                os.path.join(self.diff_files_dir, 'eplusout_duplicate_header.csv'),
+                os.path.join(self.temp_output_dir, 'abs_diff.csv'),
+                os.path.join(self.temp_output_dir, 'rel_diff.csv'),
+                os.path.join(self.temp_output_dir, 'math_diff.log'),
+                os.path.join(self.temp_output_dir, 'summary.csv'),
+            )
+
     def test_small_diff_in_watts_files(self):
         """This tests the ability to capture diffs in a regular (not-temperature) variable"""
         response = math_diff(

--- a/energyplus_regressions/tests/test_energyplus.py
+++ b/energyplus_regressions/tests/test_energyplus.py
@@ -2,9 +2,10 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from energyplus_regressions.builds.base import BuildTree
-from energyplus_regressions.energyplus import ExecutionArguments, execute_energyplus
+from energyplus_regressions.energyplus import ExecutionArguments, execute_energyplus, link_or_copy
 from energyplus_regressions.structures import ReportingFreq, ForceRunType
 
 
@@ -199,3 +200,13 @@ class TestEnergyPlus(unittest.TestCase):
         self.assertEqual('entry_name', return_val[1])
         self.assertFalse(return_val[2])  # Fail
         self.assertFalse(return_val[3])
+
+    def test_link_or_copy_falls_back_to_copy(self):
+        source = self.run_dir / 'source.txt'
+        destination = self.run_dir / 'destination.txt'
+        source.write_text('contents')
+
+        with patch('energyplus_regressions.energyplus.os.link', side_effect=OSError):
+            link_or_copy(source, destination)
+
+        self.assertEqual('contents', destination.read_text())

--- a/energyplus_regressions/tests/test_runtests.py
+++ b/energyplus_regressions/tests/test_runtests.py
@@ -2290,6 +2290,11 @@ class TestTestSuiteRunner(unittest.TestCase):
         diff_file = self.temp_base_build_dir / 'perf_log.diff'
         self.assertEqual(TextDifferences.EQUAL, SuiteRunner.diff_perf_log(base_perf_log, mod_perf_log, diff_file))
 
+    def test_perf_log_exact_match(self):
+        base_perf_log = self.resources / 'eplusout_perflog_base.csv'
+        diff_file = self.temp_base_build_dir / 'perf_log.diff'
+        self.assertEqual(TextDifferences.EQUAL, SuiteRunner.diff_perf_log(base_perf_log, base_perf_log, diff_file))
+
     def test_perf_log_diffs(self):
         base_perf_log = self.resources / 'eplusout_perflog_base.csv'
         mod_perf_log = self.resources / 'eplusout_perflog_mod.csv'
@@ -2377,6 +2382,19 @@ class TestTestSuiteRunner(unittest.TestCase):
         file_path_to_read = self.resources / 'BadUTF8Marker.idf'
         # this should simply pass without throwing an exception
         SuiteRunner.read_file_content(file_path_to_read)
+
+    def test_run_build_delegates_prepared_runs(self):
+        runner = object.__new__(SuiteRunner)
+        build_tree = object()
+        prepared_runs = [object()]
+        calls = []
+
+        runner.prepare_build_runs = lambda build: prepared_runs if build is build_tree else []
+        runner.execute_energyplus_runs = lambda runs: calls.append(runs)
+
+        runner.run_build(build_tree)
+
+        self.assertEqual([prepared_runs], calls)
 
 
 class TestSQLiteForce(unittest.TestCase):


### PR DESCRIPTION
- The EnergyPlus execution wrapper now avoids process-wide `chdir` and global environment mutation, and instead runs each tool with an explicit working directory and environment. Subprocess calls are   centralized through a shared helper, avoid `shell=True`, support Python-script executables, and capture stdout/stderr consistently. Input files such as the IDD and weather file are hard-linked when possible,  falling back to copy.

- The suite runner now prepares runs for both builds up front and executes them through the same multiprocessing path, instead of running build A and build B sequentially. This should improve worker   utilization during full regression runs.

- The diffing path also adds fast exact-match checks for math, text, perf log, GLHE, and JSON comparisons,  plus caches the math threshold dictionary. This avoids unnecessary parsing and diff generation for files that are already byte-for-byte identical.